### PR TITLE
DFI Packet Buffer

### DIFF
--- a/dev/dfi/buffer_device.c
+++ b/dev/dfi/buffer_device.c
@@ -27,11 +27,6 @@ void dfi_buffer_init(dfi_buffer_dev_t *dfi_buffer, uint32_t base)
 {
     dfi_buffer->base = base;
     dfi_buffer_init_reg_if(dfi_buffer, base);
-    dfi_tx_packet_buffer_init(&dfi_buffer->tx_packet_buffer,
-                              &dfi_buffer->tx_packets[0],
-                              PACKET_BUFFER_DEPTH);
-    dfi_rx_packet_buffer_init(&dfi_buffer->rx_packet_buffer);
-
     // By default, enable hold feature
     dfi_buffer_set_wdata_hold_reg_if(dfi_buffer, true);
 }
@@ -90,7 +85,8 @@ static wddr_return_t dfi_buffer_write_packets(dfi_buffer_dev_t *dfi_buffer,
 
 
 wddr_return_t dfi_buffer_read_packets(dfi_buffer_dev_t *dfi_buffer,
-                                            uint8_t num_packets)
+                                      dfi_rx_packet_buffer_t *rx_buffer,
+                                      uint8_t num_packets)
 {
     wddr_return_t ret;
     uint8_t nn = 0;
@@ -103,7 +99,7 @@ wddr_return_t dfi_buffer_read_packets(dfi_buffer_dev_t *dfi_buffer,
     do
     {
 
-        ret = dfi_buffer_read_eg_fifo_reg_if(dfi_buffer, dfi_buffer->rx_packet_buffer.buffer[nn].raw_data);
+        ret = dfi_buffer_read_eg_fifo_reg_if(dfi_buffer, rx_buffer->buffer[nn].raw_data);
     } while(++nn < num_packets && ret == WDDR_SUCCESS);
     return ret;
 }

--- a/include/dev/dfi/buffer_device.h
+++ b/include/dev/dfi/buffer_device.h
@@ -35,18 +35,11 @@ typedef enum dfi_fifo_state_t
  * @details Device representing send and receive sides of DFI Buffer (FIFO).
  *
  * base                 base address of the DFI Buffer Device.
- * tx_packet_buffer     internal tx packet buffer that can be used to send Commands
- *                      to the DRAM.
- * tx_packets           storage of DFI TX Packets used with TX packet buffer member.
- * rx_packet_buffer     rx packet buffer for storing received DFI packets.
  * ig_empty_completion  completion variable for synchronization of ig_empty event.
  */
 typedef struct dfi_buffer_dev_t
 {
     uint32_t                base;
-    dfi_tx_packet_buffer_t  tx_packet_buffer;
-    packet_item_t           tx_packets[PACKET_BUFFER_DEPTH];
-    dfi_rx_packet_buffer_t  rx_packet_buffer;
     Completion_t            ig_empty_completion;
 } dfi_buffer_dev_t;
 
@@ -134,6 +127,7 @@ wddr_return_t dfi_buffer_fill_and_send_packets(dfi_buffer_dev_t *dfi_buffer,
  * @details Read given number of packets from the EG FIFO.
  *
  * @param[in]       dfi_buffer      pointer to the DFI Buffer device.
+ * @param[out]      rx_buffer       pointer to the RX Packet buffer to read into.
  * @param[inout]    num_packets     number of packets to read / were read.
  *
  * @return          returns if requested number of packets were read.
@@ -142,6 +136,7 @@ wddr_return_t dfi_buffer_fill_and_send_packets(dfi_buffer_dev_t *dfi_buffer,
  *                  number of requested packets have been read.
  */
 wddr_return_t dfi_buffer_read_packets(dfi_buffer_dev_t *dfi_buffer,
+                                      dfi_rx_packet_buffer_t *rx_buffer,
                                       uint8_t num_packets);
 
 #endif /* _DFI_BUFFER_DEV_H_ */

--- a/include/dev/dfi/packet.h
+++ b/include/dev/dfi/packet.h
@@ -452,19 +452,13 @@ typedef struct packet_item_t
  * @details In memory packet buffer that is used to prepare DFI packets
  *          prior to flushing to hardware.
  *
- * num_packets      number of packets allocated in packet storage.
- * packet_index     index of next packet allocation.
  * ts_last_packet   timestamp of last packet stored in buffer.
  * list             linked list of packets. (This is the "buffer").
- * packets          pointer to storage where packets have been allocated.
  */
 typedef struct dfi_tx_packet_buffer_t
 {
-    uint8_t         num_packets;
-    uint8_t         packet_index;
     uint16_t        ts_last_packet;
     List_t          list;
-    packet_item_t   *packets;
 } dfi_tx_packet_buffer_t;
 
 /**
@@ -528,14 +522,21 @@ wddr_return_t dfi_tx_packet_buffer_fill(command_t *command,
  * @details Initializes a TX packet buffer.
  *
  * @param[out]  buffer      pointer to tx packet buffer.
- * @param[in]   packet      pointer to packet storage for the buffer.
- * @param[in]   num_packets number of packets allocated via storage.
  *
  * @return      void
  */
-void dfi_tx_packet_buffer_init(dfi_tx_packet_buffer_t *buffer,
-                               packet_item_t *packets,
-                               uint8_t num_packets);
+void dfi_tx_packet_buffer_init(dfi_tx_packet_buffer_t *buffer);
+
+/**
+ * @brief   DFI TX Packet Buffer Free
+ *
+ * @details Frees all packets in the TX packet buffer.
+ *
+ * @param[in]   buffer  pointer to tx packet buffer to free.
+ *
+ * @return  void
+ */
+void dfi_tx_packet_buffer_free(dfi_tx_packet_buffer_t *buffer);
 
 /**
  * @brief   DFI RX Packet Buffer Init


### PR DESCRIPTION
Fixes:
  - None

Features:
  - Removed TX / RX Packet Buffers from dfi_buffer_dev_t
    device
  - Packets now allocated on the heap