### PR TITLE
New DFI Packet API

### DIFF
--- a/dev/dfi/buffer_device.c
+++ b/dev/dfi/buffer_device.c
@@ -49,16 +49,22 @@ wddr_return_t dfi_buffer_fill_packets(dfi_buffer_dev_t *dfi_buffer,
     return WDDR_SUCCESS;
 }
 
-void dfi_buffer_send_packets(dfi_buffer_dev_t *dfi_buffer)
+void dfi_buffer_send_packets(dfi_buffer_dev_t *dfi_buffer, bool should_block)
 {
-    dfi_buffer_send_packets_reg_if(dfi_buffer);
+    // Call blocking version of API
+    if (should_block)
+    {
+        return dfi_buffer_send_packets_reg_if(dfi_buffer);
+    }
+
+    return dfi_buffer_send_packets_non_blocking_reg_if(dfi_buffer);
 }
 
 wddr_return_t dfi_buffer_fill_and_send_packets(dfi_buffer_dev_t *dfi_buffer,
                                                List_t *packet_list)
 {
     PROPAGATE_ERROR(dfi_buffer_fill_packets(dfi_buffer, packet_list));
-    dfi_buffer_send_packets(dfi_buffer);
+    dfi_buffer_send_packets(dfi_buffer, true);
     return WDDR_SUCCESS;
 }
 

--- a/dev/dfi/command.c
+++ b/dev/dfi/command.c
@@ -31,7 +31,9 @@ static void set_command_chipselect(command_frame_t frame[MAX_COMMAND_FRAMES],
 {
     // Chipselect
     frame[0].cs = CS_HIGH << cs;
+    frame[1].cs = 0;
     frame[2].cs = CS_HIGH << cs;
+    frame[3].cs = 0;
 }
 
 static void create_self_refresh_entry_frame(command_frame_t frame[MAX_COMMAND_FRAMES],

--- a/dev/dfi/packet.c
+++ b/dev/dfi/packet.c
@@ -3,98 +3,57 @@
  *
  * SPDX-License-Identifier: GPL-3.0
  */
-#include <dfi/packet.h>
+#include <stdbool.h>
 #include <string.h>
+#include <dfi/packet.h>
 
 #define DFI_PACK_CKE_VAL        ((WDDR_PHY_RANK << 1) - 1)
-#define GET_LAST_ITEM(LIST)     (listGET_PREV((MiniListItem_t *) listGET_END_MARKER(LIST)))
-#define GET_LAST_PACKET(LIST)   ((packet_item_t *) listGET_LIST_ITEM_OWNER(GET_LAST_ITEM(LIST)))
-#define FREE_PACKET(PACKET)     \
-    {                           \
-        uxListRemove(PACKET);   \
-        vPortFree(PACKET);      \
-    }
 
-static dfi_command_cfg_t dfi_command_mission_cfg =
-{
-    .group_offsets    = {
-        {0,0,0,0,0,0,0,0},      // Write Level
-        {0,0,0,0,0,0,0,0},      // Read
-        {0,0,0,0,0,0,0,0},      // Write
-        {0,0,0,4,0,0,19,19},    // MRR  (TODO: Need to verify)
-        {0,0,0,0,0,0,0,0},      // MRW
-        {0,0,0,0,0,0,0,0},      // CK
-        {0,0,0,0,0,0,0,0},      // CKE
-        {0,20,20,20,0,0,0,0},   // CBT
-        {0,0,0,0,0,0,0,0}       // SR
-    },
-    .group_lengths    = {
-        {8,8,0,0,8,0,0,0},      // Write Level
-        {0,0,4,4,0,0,0,0},      // Read
-        {0,0,4,4,0,0,0,0},      // Write
-        {23,23,4,4,0,0,4,4},    // MRR  (TODO: Use same timing as READ)
-        {6,6,4,4,0,0,0,0},      // MRW
-        {1,0,0,0,0,0,0,0},      // CK
-        {1,1,0,0,0,0,0,0},      // CKE
-        {24,0,4,4,2,20,0,0},    // CBT
-        {4,4,2,2,0,0,0,0}       // SR
-    },
-    // Packet Group Phases
-    .group_num_phases = {1,1,1,1,2,2,2,2},
-};
+/** @brief  Internal Function for creating a new packet_item_t instance */
+static void create_packet(dfi_tx_packet_buffer_t *buffer, packet_item_t **packet);
 
-/**
- * @brief   DFI Command Fill Packet Group
- *
- * @details Helper function to fill in a particular group of a DFI packet.
- *
- * @param[in]       command         pointer to command that packet belongs to.
- * @param[out]      packet          pointer to packet to fill in.
- * @param[inout]    phase_offset    pointer to how many phases have been filled
- *                                  in for given packet group for given command.
- * @param[in]       group           which packet group to fill.
- * @param[in]       phase_mask      mask to indicate which phases to fill in.
- *
- * @return  void
- */
-static void dfi_command_fill_packet_group(command_t *command,
-                                          dfi_tx_packet_t *packet,
-                                          uint8_t *phase_offset,
-                                          uint8_t group,
-                                          uint8_t phase_mask);
-/**
- * @brief   DFI TX Packet Buffer Insert Packet
- *
- * @details Helper function that inserts a packet for given timestamp
- *          if it's not already in the list.
- *
- * @param[in]   buffer      pointer to packet buffer that packet belongs to.
- * @param[in]   timestamp   timestamp of pcaket to insert.
- * @param[in]   head        pointer to list to search / add packet to.
- *
- * @return      returns whether timestamp was accounted for.
- * @retval      WDDR_SUCCESS if added or already present.
- * @retval      WDDR_ERROR if packet couldn't be allocated.
- */
-static wddr_return_t dfi_tx_packet_buffer_insert_packet(dfi_tx_packet_buffer_t *buffer,
-                                                        uint16_t timestamp,
-                                                        List_t *head);
+/** @brief  Internal Function for creating sequence of packets to send command to DRAM */
+static wddr_return_t create_address_packet_sequence(dfi_tx_packet_buffer_t *buffer,
+                                                    wddr_freq_ratio_t ratio,
+                                                    command_t *command,
+                                                    uint16_t time_offset);
 
+/** @brief  Internal Function for extracting data from a packet and storing in a data buffer */
+static void extract_packet_data(dfi_rx_packet_desc_t *packet,
+                                uint8_t data_packet[PACKET_MAX_NUM_PHASES],
+                                wddr_dq_byte_t dq_byte,
+                                uint8_t phases);
+
+/** @brief  Internal Function to compare received data versus expected data */
+static bool compare_received_data(uint8_t received[PACKET_MAX_NUM_PHASES],
+                                  uint8_t *expected,
+                                  uint8_t phases,
+                                  packet_data_mask_t data_mask);
 
 void dfi_tx_packet_buffer_init(dfi_tx_packet_buffer_t *buffer)
 {
     vListInitialise(&buffer->list);
     buffer->ts_last_packet = 1;
+    buffer->storage = NULL;
 }
 
 void dfi_tx_packet_buffer_free(dfi_tx_packet_buffer_t *buffer)
 {
     ListItem_t *pxCurr, *pxNext;
+    packet_item_t *packet;
     listFOR_EACH_LIST_ITEM_SAFE(pxCurr, pxNext, &buffer->list)
     {
-        FREE_PACKET(pxCurr);
+        uxListRemove(pxCurr);
+        if (buffer->storage == NULL)
+        {
+            packet = (packet_item_t *) listGET_LIST_ITEM_OWNER(pxCurr);
+            vPortFree(packet);
+        }
+        else
+        {
+            buffer->storage->index--;
+        }
     }
-
     buffer->ts_last_packet = 1;
 }
 
@@ -103,348 +62,78 @@ void dfi_rx_packet_buffer_init(dfi_rx_packet_buffer_t *buffer)
     memset(buffer, 0, sizeof(dfi_rx_packet_buffer_t));
 }
 
-void dfi_tx_packet_get_mission_cfg(dfi_command_cfg_t **cfg)
-{
-    *cfg = &dfi_command_mission_cfg;
-}
 
-static void dfi_command_fill_packet_group(command_t *command,
-                                          dfi_tx_packet_t *packet,
-                                          uint8_t *phase_offset,
-                                          uint8_t group,
-                                          uint8_t phase_mask)
+
+wddr_return_t create_ck_packet_sequence(dfi_tx_packet_buffer_t *buffer,
+                                        uint16_t time_offset)
 {
-    switch (group)
+    packet_item_t *packet;
+    create_packet(buffer, &packet);
+    if (packet == NULL)
     {
-        case PACKET_GROUP_COMMAND_DCE:
-            packet->packet.dce_p0 = 1;
-            packet->packet.dce_p1 = 1;
-            packet->packet.dce_p2 = 1;
-            packet->packet.dce_p3 = 1;
-            break;
-        case PACKET_GROUP_COMMAND_CKE:
-            packet->packet.cke_p0 = DFI_PACK_CKE_VAL;
-            packet->packet.cke_p1 = DFI_PACK_CKE_VAL;
-            packet->packet.cke_p2 = DFI_PACK_CKE_VAL;
-            packet->packet.cke_p3 = DFI_PACK_CKE_VAL;
-            break;
-        case PACKET_GROUP_COMMAND_CS:
-            if (phase_mask & 0x1)
-            {
-                packet->packet.cs_p0 = command->address[*phase_offset].cs;
-                packet->packet.cs_p1 = command->address[*phase_offset].cs;
-                *phase_offset += 1;
-            }
-            if (phase_mask & 0x2)
-            {
-                packet->packet.cs_p2 = command->address[*phase_offset].cs;
-                packet->packet.cs_p3 = command->address[*phase_offset].cs;
-                *phase_offset += 1;
-            }
-            break;
-        case PACKET_GROUP_COMMAND:
-            // TODO: Need Phase 1 & 3 for LPDDR5??
-            if (phase_mask & 0x1)
-            {
-                packet->packet.address_p0 = command->address[*phase_offset].ca_pins;
-                *phase_offset += 1;
-            }
-            if (phase_mask & 0x2)
-            {
-                packet->packet.address_p2 = command->address[*phase_offset].ca_pins;
-                *phase_offset += 1;
-            }
-            break;
-        case PACKET_GROUP_WRDATA_EN:
-            if (phase_mask & 0x1)
-            {
-                packet->packet.wrdata_en_p0 = 1;
-                packet->packet.wrdata_en_p1 = 1;
-                *phase_offset += 2;
-            }
-
-            if (phase_mask & 0x2)
-            {
-                packet->packet.wrdata_en_p2 = 1;
-                packet->packet.wrdata_en_p3 = 1;
-                *phase_offset += 2;
-            }
-            break;
-        case PACKET_GROUP_WRDATA:
-            if (phase_mask & 0x1)
-            {
-                packet->packet.wrdata_cs_p0  = 1 << command->cs;
-                packet->packet.dq0_wrdata_p0 = command->data->dq[0][*phase_offset];
-                packet->packet.dq1_wrdata_p0 = command->data->dq[1][*phase_offset];
-                packet->packet.dq0_wrdata_mask_p0 = command->data->dm[0][*phase_offset];
-                packet->packet.dq1_wrdata_mask_p0 = command->data->dm[1][*phase_offset];
-                packet->packet.wrdata_cs_p1  = 1 << command->cs;
-                packet->packet.dq0_wrdata_p1 = command->data->dq[0][*phase_offset + 1];
-                packet->packet.dq1_wrdata_p1 = command->data->dq[1][*phase_offset + 1];
-                packet->packet.dq0_wrdata_mask_p1 = command->data->dm[0][*phase_offset + 1];
-                packet->packet.dq1_wrdata_mask_p1 = command->data->dm[1][*phase_offset + 1];
-                *phase_offset += 2;
-            }
-
-            if (phase_mask & 0x2)
-            {
-                packet->packet.wrdata_cs_p2  = 1 << command->cs;
-                packet->packet.dq0_wrdata_p2 = command->data->dq[0][*phase_offset];
-                packet->packet.dq1_wrdata_p2 = command->data->dq[1][*phase_offset];
-                packet->packet.dq0_wrdata_mask_p2 = command->data->dm[0][*phase_offset];
-                packet->packet.dq1_wrdata_mask_p2 = command->data->dm[1][*phase_offset];
-                packet->packet.wrdata_cs_p3  = 1 << command->cs;
-                packet->packet.dq0_wrdata_p3 = command->data->dq[0][*phase_offset + 1];
-                packet->packet.dq1_wrdata_p3 = command->data->dq[1][*phase_offset + 1];
-                packet->packet.dq0_wrdata_mask_p3 = command->data->dm[0][*phase_offset + 1];
-                packet->packet.dq1_wrdata_mask_p3 = command->data->dm[1][*phase_offset + 1];
-                *phase_offset += 2;
-            }
-            break;
-        case PACKET_GROUP_RDDATA_EN:
-            if (phase_mask & 0x1)
-            {
-                packet->packet.rddata_en_p0 = 1;
-                packet->packet.rddata_en_p1 = 1;
-                *phase_offset += 2;
-            }
-
-            if (phase_mask & 0x2)
-            {
-                packet->packet.rddata_en_p2 = 1;
-                packet->packet.rddata_en_p3 = 1;
-                *phase_offset += 2;
-            }
-            break;
-        case PACKET_GROUP_RDDATA_CS:
-            if (phase_mask & 0x1)
-            {
-                packet->packet.rddata_cs_p0 = 1 << command->cs;
-                packet->packet.rddata_cs_p1 = 1 << command->cs;
-                *phase_offset += 2;
-            }
-            if (phase_mask & 0x2)
-            {
-                packet->packet.rddata_cs_p2 = 1 << command->cs;
-                packet->packet.rddata_cs_p3 = 1 << command->cs;
-                *phase_offset += 2;
-            }
-            break;
+        return WDDR_ERROR;
     }
-}
 
-static wddr_return_t dfi_tx_packet_buffer_insert_packet(dfi_tx_packet_buffer_t *buffer,
-                                                        uint16_t timestamp,
-                                                        List_t *head)
-{
-    packet_item_t *current_packet;
-    // Search through packet list for command and find where to insert
-    // Have to find at least one because of the end packet that's added
-    if (!vListIsItemValueContainedWithin(head, timestamp))
-    {
-        current_packet = pvPortMalloc(sizeof(packet_item_t));
-        if (current_packet == NULL)
-        {
-            return WDDR_ERROR;
-        }
+    time_offset += buffer->ts_last_packet;
+    packet->packet.packet.dce_p0 = 1;
+    packet->packet.packet.dce_p1 = 1;
+    packet->packet.packet.dce_p2 = 1;
+    packet->packet.packet.dce_p3 = 1;
+    packet->packet.packet.time = time_offset;
+    buffer->ts_last_packet = time_offset - 1;
 
-        vListInitialiseItem(&current_packet->list_item);
-        current_packet->packet.packet.time = timestamp;
-        listSET_LIST_ITEM_VALUE(&current_packet->list_item, timestamp);
-        listSET_LIST_ITEM_OWNER(&current_packet->list_item, current_packet);
-        vListInsert(head, &current_packet->list_item);
-    }
+    // Add to list
+    vListInitialiseItem(&packet->list_item);
+    packet->packet.packet.time = time_offset;
+    listSET_LIST_ITEM_VALUE(&packet->list_item, time_offset);
+    listSET_LIST_ITEM_OWNER(&packet->list_item, packet);
+    vListInsert(&buffer->list, &packet->list_item);
 
     return WDDR_SUCCESS;
 }
 
-/**
- *
- * @todo    This function is complicated and difficult to understand. It needs
- *          to be better documented. A potential redsign or more straight
- *          forward approach should be considered.
- */
-wddr_return_t dfi_tx_packet_buffer_fill(command_t *command,
-                                       dfi_tx_packet_buffer_t *buffer,
-                                       dfi_command_cfg_t *cfg,
-                                       uint16_t ts_offset)
+wddr_return_t create_cke_packet_sequence(dfi_tx_packet_buffer_t *buffer,
+                                         uint16_t time_offset)
 {
-    uint16_t group_offset, group_packet_length, num_packets;
-    uint16_t start_time;
-    uint16_t *group_lengths;
-    uint8_t *group_num_phases;
-    packet_item_t *current_packet, *last_packet;
-    List_t command_list;
-    ListItem_t *item;
-    uint8_t ratio = cfg->ratio;
-
-    vListInitialise(&command_list);
-
-    // Based on DRAM Cycles
-    group_lengths = cfg->group_lengths[command->command_type];
-    group_num_phases = cfg->group_num_phases;
-
-    start_time = listLIST_IS_EMPTY(&buffer->list) ? buffer->ts_last_packet : buffer->ts_last_packet + ts_offset;
-
-    /*******************************************************************
-     **                         PART 1
-     *******************************************************************
-     ** Process each packet group. Create the minimum number of packets
-     ** required to create the correct DFI signal sequence. Add
-     ** timestamps to internal list, creating a "timeline" of packets.
-     *******************************************************************
-     ******************************************************************/
-    for (uint8_t group_index = 0; group_index < PACKET_GROUP_TOTAL_NUM; group_index++)
+    packet_item_t *packet;
+    create_packet(buffer, &packet);
+    if (packet == NULL)
     {
-        uint8_t offset_remainder, length_remainder, phases_per_packet;
-
-        // Skip group_length of zero
-        if (group_lengths[group_index] == 0)
-        {
-            continue;
-        }
-
-        phases_per_packet = group_num_phases[group_index] * ratio;
-
-        // Group Offset determines timestamp where this group starts as offset from start_time
-        group_offset = cfg->group_offsets[command->command_type][group_index] / ratio;
-        offset_remainder = cfg->group_offsets[command->command_type][group_index] % ratio;
-
-        // Determine number of packets required
-        group_packet_length = group_lengths[group_index] / phases_per_packet;
-        length_remainder = group_lengths[group_index] % phases_per_packet;
-
-        if (offset_remainder || length_remainder)
-        {
-            // Need extra packet for either case
-            group_packet_length += 1;
-        }
-
-        // CKE / CK only require one packet to produce correct pattern.
-        if (group_index <= PACKET_GROUP_COMMAND_CKE)
-        {
-            num_packets = 1;
-        }
-        // COMMAND / WRITE / READ
-        else
-        {
-            num_packets = group_packet_length;
-        }
-
-        /**
-         * NOTE: 2 Types of allocations required for each group
-         * 1. Unique packets per group : start + any others
-         * 2. Where group ends + 1 (Think as packet to turn off group)
-         */
-
-        // This accounts for 1
-        for (uint16_t time_offset = start_time + group_offset; time_offset < start_time + group_offset + num_packets; time_offset++)
-        {
-            PROPAGATE_ERROR(dfi_tx_packet_buffer_insert_packet(buffer, time_offset, &command_list));
-        }
-
-        // This accounts for 2
-        PROPAGATE_ERROR(dfi_tx_packet_buffer_insert_packet(buffer, start_time + group_offset + group_packet_length, &command_list));
+        return WDDR_ERROR;
     }
 
-    /*******************************************************************
-     **                         PART 2
-     *******************************************************************
-     ** Fill in the packets created in PART 1 based on which groups
-     ** are valid within the timestamp of each packet.
-     *******************************************************************
-     ******************************************************************/
-    for (uint8_t group_index = 0; group_index < PACKET_GROUP_TOTAL_NUM; group_index++)
-    {
-        // Skip group_length of zero
-        if (group_lengths[group_index] == 0)
-        {
-            continue;
-        }
+    time_offset += buffer->ts_last_packet;
+    packet->packet.packet.dce_p0 = 1;
+    packet->packet.packet.dce_p1 = 1;
+    packet->packet.packet.dce_p2 = 1;
+    packet->packet.packet.dce_p3 = 1;
+    packet->packet.packet.cke_p0 = DFI_PACK_CKE_VAL;
+    packet->packet.packet.cke_p1 = DFI_PACK_CKE_VAL;
+    packet->packet.packet.cke_p2 = DFI_PACK_CKE_VAL;
+    packet->packet.packet.cke_p3 = DFI_PACK_CKE_VAL;
+    packet->packet.packet.time = time_offset;
+    buffer->ts_last_packet = time_offset - 1;
 
-        group_packet_length = group_lengths[group_index];
-        group_offset = cfg->group_offsets[command->command_type][group_index] / ratio;
+    // Add to list
+    vListInitialiseItem(&packet->list_item);
+    packet->packet.packet.time = time_offset;
+    listSET_LIST_ITEM_VALUE(&packet->list_item, time_offset);
+    listSET_LIST_ITEM_OWNER(&packet->list_item, packet);
+    vListInsert(&buffer->list, &packet->list_item);
 
-        uint8_t phases_per_packet = group_num_phases[group_index] * ratio;
-        uint8_t offset_remainder = cfg->group_offsets[command->command_type][group_index] % ratio;
-        uint8_t length_remainder = group_lengths[group_index] % phases_per_packet;
-        uint16_t group_start = start_time + group_offset;
-        uint16_t group_end_time = group_start + (group_packet_length / phases_per_packet) + (offset_remainder || length_remainder ? 1 : 0);
-        uint8_t phase_offset = 0;
-
-        uint8_t phase_mask = ((1 << ratio) - 1);
-        if (group_packet_length < phases_per_packet)
-        {
-            phase_mask = (1 << (group_packet_length / group_num_phases[group_index])) - 1;
-        }
-        else if (offset_remainder)
-        {
-            phase_mask = 1 << offset_remainder;
-        }
-
-        // Fill in packets based on if they're valid at packet timestamp for this group
-        listFOR_EACH_LIST_ITEM(item, &command_list)
-        {
-            current_packet = (packet_item_t *) listGET_LIST_ITEM_OWNER(item);
-            // Within time window that group should write
-            if (group_start <= current_packet->packet.packet.time && current_packet->packet.packet.time < group_end_time)
-            {
-                // Fill in packet for this group
-                dfi_command_fill_packet_group(command,
-                                              &current_packet->packet,
-                                              &phase_offset,
-                                              group_index,
-                                              phase_mask);
-                phase_mask = ((1 << ((group_packet_length - phase_offset) / group_num_phases[group_index])) - 1) & ((1 << ratio) - 1);
-            }
-        }
-    }
-
-    // Get last valid packet end timestamp and remove extra packet
-    last_packet = GET_LAST_PACKET(&command_list);
-    buffer->ts_last_packet = last_packet->packet.packet.time - 1;
-    FREE_PACKET(&last_packet->list_item);
-
-    // Add to existing packet list
-    vListSplice(&buffer->list, &command_list);
     return WDDR_SUCCESS;
 }
 
-// TODO: Need to support 8 phases
-static void dfi_buffer_convert_packet_to_array(wddr_dq_byte_t dq_byte,
-                                               dfi_rx_packet_desc_t *packet,
-                                               uint8_t data_packet[PACKET_MAX_NUM_PHASES],
-                                               uint8_t phases)
+wddr_return_t create_mrw_packet_sequence(dfi_tx_packet_buffer_t *buffer,
+                                        wddr_freq_ratio_t ratio,
+                                        chipselect_t cs,
+                                        uint8_t mode_register,
+                                        uint8_t op,
+                                        uint16_t time_offset)
 {
-    data_packet[0] = (dq_byte == WDDR_DQ_BYTE_0) ? packet->dq0_dfi_rddata_w0 : packet->dq1_dfi_rddata_w0;
-    data_packet[1] = (dq_byte == WDDR_DQ_BYTE_0) ? packet->dq0_dfi_rddata_w1 : packet->dq1_dfi_rddata_w1;
-
-    if (phases == 4)
-    {
-        data_packet[2] = (dq_byte == WDDR_DQ_BYTE_0) ? packet->dq0_dfi_rddata_w2 : packet->dq1_dfi_rddata_w2;
-        data_packet[3] = (dq_byte == WDDR_DQ_BYTE_0) ? packet->dq0_dfi_rddata_w3 : packet->dq1_dfi_rddata_w3;
-    }
-}
-static void dfi_buffer_rx_cycle_data_compare(uint8_t packet_data[PACKET_MAX_NUM_PHASES],
-                                           uint8_t *data,
-                                           uint8_t phases,
-                                           packet_data_mask_t data_mask,
-                                           uint8_t *is_same)
-{
-    uint8_t same = 1;
-    uint8_t step_size = data_mask == PACKET_DATA_MASK_BOTH ? 1 : 2;
-    uint8_t i = data_mask & PACKET_DATA_MASK_EVEN ? 0 : 1;
-
-    // compare all phases
-    for (; i < phases; i += step_size)
-    {
-        if (data[i] != packet_data[i])
-        {
-            same = 0;
-            break;
-        }
-    }
-    *is_same = same;
+    command_t command = {0};
+    create_write_mode_register_command(&command, cs, mode_register, op);
+    return create_address_packet_sequence(buffer, ratio, &command, time_offset);
 }
 
 void dfi_rx_packet_buffer_data_compare(dfi_rx_packet_buffer_t *buffer,
@@ -456,16 +145,135 @@ void dfi_rx_packet_buffer_data_compare(dfi_rx_packet_buffer_t *buffer,
                                        uint8_t *is_same)
 {
     dfi_rx_packet_desc_t *packet;
+    bool same = false;
     uint8_t data_packet[PACKET_MAX_NUM_PHASES];
 
     for (uint8_t ii = 0; ii < num; ii++)
     {
         packet = &buffer->buffer[ii].packet;
-        dfi_buffer_convert_packet_to_array(dq_byte, packet, data_packet, phases);
-        dfi_buffer_rx_cycle_data_compare(data_packet, &expected->dq[dq_byte][ii * phases], phases, data_mask, is_same);
-        if (*is_same == 0)
+        extract_packet_data(packet, data_packet, dq_byte, phases);
+        same = compare_received_data(data_packet, &expected->dq[dq_byte][ii * phases], phases, data_mask);
+        if (!same)
         {
             break;
         }
     }
+    *is_same = same;
+}
+
+static void create_packet(dfi_tx_packet_buffer_t *buffer, packet_item_t **packet)
+{
+    packet_item_t *new_packet = NULL;
+
+    if (buffer->storage != NULL && buffer->storage->packets != NULL)
+    {
+        if (buffer->storage->index < buffer->storage->len)
+        {
+
+            new_packet = &buffer->storage->packets[buffer->storage->index++];
+        }
+    }
+    else
+    {
+        new_packet = pvPortMalloc(sizeof(packet_item_t));
+        // Intialize packet
+        for (uint8_t i = 0; i < TX_PACKET_SIZE_WORDS; i--)
+        {
+            new_packet->packet.raw_data[i] = 0;
+        }
+    }
+
+    *packet = new_packet;
+}
+
+static wddr_return_t create_address_packet_sequence(dfi_tx_packet_buffer_t *buffer,
+                                                    wddr_freq_ratio_t ratio,
+                                                    command_t *command,
+                                                    uint16_t time_offset)
+{
+    uint8_t phase_offset = 0;
+    uint8_t num_packets = (MAX_COMMAND_FRAMES >> ratio);
+    // Five packets required for this command
+    packet_item_t *packet;
+
+    time_offset += buffer->ts_last_packet;
+
+    for (uint8_t i = 0; i < num_packets; i++)
+    {
+        create_packet(buffer, &packet);
+        if (packet == NULL)
+        {
+            return WDDR_ERROR;
+        }
+
+        packet->packet.packet.dce_p0 = 1;
+        packet->packet.packet.dce_p1 = 1;
+        packet->packet.packet.dce_p2 = 1;
+        packet->packet.packet.dce_p3 = 1;
+        packet->packet.packet.cke_p0 = DFI_PACK_CKE_VAL;
+        packet->packet.packet.cke_p1 = DFI_PACK_CKE_VAL;
+        packet->packet.packet.cke_p2 = DFI_PACK_CKE_VAL;
+        packet->packet.packet.cke_p3 = DFI_PACK_CKE_VAL;
+
+        // Command
+        packet->packet.packet.cs_p0 = command->address[phase_offset].cs;
+        packet->packet.packet.cs_p1 = command->address[phase_offset].cs;
+        packet->packet.packet.address_p0 = command->address[phase_offset].ca_pins;
+        phase_offset++;
+
+        if (ratio == WDDR_FREQ_RATIO_1TO2)
+        {
+            packet->packet.packet.cs_p2 = command->address[phase_offset].cs;
+            packet->packet.packet.cs_p3 = command->address[phase_offset].cs;
+            packet->packet.packet.address_p2 = command->address[phase_offset].ca_pins;
+            phase_offset++;
+        }
+
+        // Add to list
+        vListInitialiseItem(&packet->list_item);
+        packet->packet.packet.time = time_offset;
+        listSET_LIST_ITEM_VALUE(&packet->list_item, time_offset);
+        listSET_LIST_ITEM_OWNER(&packet->list_item, packet);
+        vListInsert(&buffer->list, &packet->list_item);
+        time_offset++;
+    }
+
+    buffer->ts_last_packet = time_offset - 1;
+    return WDDR_SUCCESS;
+}
+
+// TODO: Need to support 8 phases
+static void extract_packet_data(dfi_rx_packet_desc_t *packet,
+                                uint8_t data_packet[PACKET_MAX_NUM_PHASES],
+                                wddr_dq_byte_t dq_byte,
+                                uint8_t phases)
+{
+    data_packet[0] = (dq_byte == WDDR_DQ_BYTE_0) ? packet->dq0_dfi_rddata_w0 : packet->dq1_dfi_rddata_w0;
+    data_packet[1] = (dq_byte == WDDR_DQ_BYTE_0) ? packet->dq0_dfi_rddata_w1 : packet->dq1_dfi_rddata_w1;
+
+    if (phases == 4)
+    {
+        data_packet[2] = (dq_byte == WDDR_DQ_BYTE_0) ? packet->dq0_dfi_rddata_w2 : packet->dq1_dfi_rddata_w2;
+        data_packet[3] = (dq_byte == WDDR_DQ_BYTE_0) ? packet->dq0_dfi_rddata_w3 : packet->dq1_dfi_rddata_w3;
+    }
+}
+
+static bool compare_received_data(uint8_t received[PACKET_MAX_NUM_PHASES],
+                                  uint8_t *expected,
+                                  uint8_t phases,
+                                  packet_data_mask_t data_mask)
+{
+    uint8_t step_size = data_mask == PACKET_DATA_MASK_BOTH ? 1 : 2;
+    uint8_t i = data_mask & PACKET_DATA_MASK_EVEN ? 0 : 1;
+
+    // compare all phases
+    for (; i < phases; i += step_size)
+    {
+        if (expected[i] != received[i])
+        {
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/dev/dram/device.c
+++ b/dev/dram/device.c
@@ -13,26 +13,12 @@
 #define CBT__SHFT       (0)
 #define CBT__MSK        (1 << CBT__SHFT)
 
-enum init_command_idx
-{
-    INIT_CK_IDX,
-    INIT_CKE_IDX,
-    INIT_MR1_IDX,
-    INIT_MR2_IDX,
-    INIT_MR11_IDX,
-    INIT_MR12_IDX,
-    INIT_MR14_IDX,
-    INIT_TOTAL_IDX,
-};
-
-enum cbt_command_idx
-{
-    CBT_CK_IDX,
-    CBT_CKE_IDX,
-    CBT_MR13_IDX,
-    CBT_CBTC_IDX,
-    CBT_TOTAL_IDX
-};
+/** @brief  Internal Function for updating DRAM Mode Register */
+static void dram_write_mode_register(__UNUSED__ dram_dev_t *dram,
+                                     dfi_buffer_dev_t *dfi_buffer,
+                                     dram_freq_cfg_t *cfg,
+                                     uint8_t mr,
+                                     uint8_t op);
 
 void dram_init(dram_dev_t *dram)
 {
@@ -40,120 +26,82 @@ void dram_init(dram_dev_t *dram)
     dram->mr2 = 0;
 }
 
-void dram_power_down(__UNUSED__ dram_dev_t *dram,
-                     dfi_buffer_dev_t *dfi_buffer,
-                     dfi_command_cfg_t *cfg)
+void dram_power_down(__UNUSED__ dram_dev_t *dram, dfi_buffer_dev_t *dfi_buffer)
 {
     dfi_tx_packet_buffer_t packet_buffer;
-    command_t command = {0};
-    command.command_type = COMMAND_TYPE_CK;
 
-     // Initialize TX Packet Buffer
     dfi_tx_packet_buffer_init(&packet_buffer);
-
-    // Get DRAM into Power Down state
-    // Force CK to toggle for at least 10 cycles without CKE
-    dfi_tx_packet_buffer_fill(&command, &packet_buffer, cfg, 1);
-    dfi_tx_packet_buffer_fill(&command, &packet_buffer, cfg, 10);
+    create_ck_packet_sequence(&packet_buffer, 1);
+    create_ck_packet_sequence(&packet_buffer, 10);
     dfi_buffer_fill_and_send_packets(dfi_buffer, &packet_buffer.list);
     dfi_tx_packet_buffer_free(&packet_buffer);
 }
 
-void dram_idle(__UNUSED__ dram_dev_t *dram,
-               dfi_buffer_dev_t *dfi_buffer,
-               dfi_command_cfg_t *cfg)
+void dram_idle(__UNUSED__ dram_dev_t *dram, dfi_buffer_dev_t *dfi_buffer)
 {
     dfi_tx_packet_buffer_t packet_buffer;
-    command_t command[2] = {0};
-    command[0].command_type = COMMAND_TYPE_CK;
-    command[1].command_type = COMMAND_TYPE_CKE;
-
-    // Initialize TX Packet Buffer
     dfi_tx_packet_buffer_init(&packet_buffer);
-
-    // Get DRAM into IDLE state
-    dfi_tx_packet_buffer_fill(&command[0], &packet_buffer, cfg, 1);
-    dfi_tx_packet_buffer_fill(&command[1], &packet_buffer, cfg, 30);
+    create_ck_packet_sequence(&packet_buffer, 1);
+    create_cke_packet_sequence(&packet_buffer, 30);
     dfi_buffer_fill_and_send_packets(dfi_buffer, &packet_buffer.list);
     dfi_tx_packet_buffer_free(&packet_buffer);
 }
-
 
 void dram_frequency_init(__UNUSED__ dram_dev_t *dram,
                          dfi_buffer_dev_t *dfi_buffer,
-                         dfi_command_cfg_t *cfg,
                          dram_freq_cfg_t *dram_cfg,
                          dram_freq_cal_t *dram_cal)
 {
     dfi_tx_packet_buffer_t packet_buffer;
-    command_t command[INIT_TOTAL_IDX] = {0};
-    command[INIT_CK_IDX].command_type = COMMAND_TYPE_CK;
-    command[INIT_CKE_IDX].command_type = COMMAND_TYPE_CKE;
-
-    create_write_mode_register_command(&command[INIT_MR1_IDX], CS_0, 0x1, dram_cfg->mr1);       // MR1
-    create_write_mode_register_command(&command[INIT_MR2_IDX], CS_0, 0x2, dram_cfg->mr2);       // MR2
-    create_write_mode_register_command(&command[INIT_MR11_IDX], CS_0, 0xB, dram_cfg->mr11);     // MR11
-    create_write_mode_register_command(&command[INIT_MR12_IDX], CS_0, 0xC, dram_cal->mr12);     // MR12
-    create_write_mode_register_command(&command[INIT_MR14_IDX], CS_0, 0xE, dram_cal->mr14);     // MR14
 
     // Initialize TX Packet Buffer
     dfi_tx_packet_buffer_init(&packet_buffer);
-
-    // Issue MR0/1/11/12/13/14
-    dfi_tx_packet_buffer_fill(&command[INIT_MR1_IDX], &packet_buffer, cfg, 1);
-    dfi_tx_packet_buffer_fill(&command[INIT_MR2_IDX], &packet_buffer, cfg, 15);
-    dfi_tx_packet_buffer_fill(&command[INIT_MR11_IDX], &packet_buffer, cfg, 15);
-    dfi_tx_packet_buffer_fill(&command[INIT_MR12_IDX], &packet_buffer, cfg, 15);
-    dfi_tx_packet_buffer_fill(&command[INIT_MR14_IDX], &packet_buffer, cfg, 15);
-    dfi_tx_packet_buffer_fill(&command[INIT_CKE_IDX], &packet_buffer, cfg, 1);
+    create_mrw_packet_sequence(&packet_buffer, dram_cfg->ratio, CS_0, 0x1, dram_cfg->mr1, 1);
+    create_mrw_packet_sequence(&packet_buffer, dram_cfg->ratio, CS_0, 0x2, dram_cfg->mr2, 15);
+    create_mrw_packet_sequence(&packet_buffer, dram_cfg->ratio, CS_0, 0xB, dram_cfg->mr11, 15);
+    create_mrw_packet_sequence(&packet_buffer, dram_cfg->ratio, CS_0, 0xC, dram_cal->mr12, 15);
+    create_mrw_packet_sequence(&packet_buffer, dram_cfg->ratio, CS_0, 0xE, dram_cal->mr14, 15);
+    create_cke_packet_sequence(&packet_buffer, 1);
     dfi_buffer_fill_and_send_packets(dfi_buffer, &packet_buffer.list);
     dfi_tx_packet_buffer_free(&packet_buffer);
 }
 
 void dram_cbt_enter(dram_dev_t *dram,
                     dfi_buffer_dev_t *dfi_buffer,
-                    dfi_command_cfg_t *cfg)
+                    dram_freq_cfg_t *cfg)
 {
     dfi_tx_packet_buffer_t packet_buffer;
-    command_t command[CBT_TOTAL_IDX] = {0};
-    command[CBT_CK_IDX].command_type = COMMAND_TYPE_CK;
-    command[CBT_CKE_IDX].command_type = COMMAND_TYPE_CKE;
 
     dram->mr13 |= CBT__MSK;
-    create_write_mode_register_command(&command[CBT_MR13_IDX], CS_0, 0xD, dram->mr13);
 
     dfi_tx_packet_buffer_init(&packet_buffer);
-    dfi_tx_packet_buffer_fill(&command[CBT_MR13_IDX], &packet_buffer, cfg, 15);
-    dfi_tx_packet_buffer_fill(&command[CBT_CKE_IDX], &packet_buffer, cfg, 1);
-    dfi_tx_packet_buffer_fill(&command[CBT_CK_IDX], &packet_buffer, cfg, 15);
+    create_mrw_packet_sequence(&packet_buffer, cfg->ratio, CS_0, 0xD, dram->mr13, 15);
+    create_cke_packet_sequence(&packet_buffer, 1);
+    create_ck_packet_sequence(&packet_buffer, 15);
     dfi_buffer_fill_and_send_packets(dfi_buffer, &packet_buffer.list);
     dfi_tx_packet_buffer_free(&packet_buffer);
 }
 
 void dram_cbt_exit(dram_dev_t *dram,
                    dfi_buffer_dev_t *dfi_buffer,
-                   dfi_command_cfg_t *cfg)
+                   dram_freq_cfg_t *cfg)
 {
     dfi_tx_packet_buffer_t packet_buffer;
-    command_t command[CBT_TOTAL_IDX] = {0};
-    command[CBT_CK_IDX].command_type = COMMAND_TYPE_CK;
-    command[CBT_CKE_IDX].command_type = COMMAND_TYPE_CKE;
 
     dram->mr13 &= ~CBT__MSK;
-    create_write_mode_register_command(&command[CBT_MR13_IDX], CS_0, 0xD, dram->mr13);
 
     dfi_tx_packet_buffer_init(&packet_buffer);
-    dfi_tx_packet_buffer_fill(&command[CBT_CK_IDX], &packet_buffer, cfg, 15);
-    dfi_tx_packet_buffer_fill(&command[CBT_CKE_IDX], &packet_buffer, cfg, 1);
-    dfi_tx_packet_buffer_fill(&command[CBT_MR13_IDX], &packet_buffer, cfg, 15);
-    dfi_tx_packet_buffer_fill(&command[CBT_CKE_IDX], &packet_buffer, cfg, 1);
+    create_ck_packet_sequence(&packet_buffer, 15);
+    create_cke_packet_sequence(&packet_buffer, 1);
+    create_mrw_packet_sequence(&packet_buffer, cfg->ratio, CS_0, 0xD, dram->mr13, 15);
+    create_cke_packet_sequence(&packet_buffer, 1);
     dfi_buffer_fill_and_send_packets(dfi_buffer, &packet_buffer.list);
     dfi_tx_packet_buffer_free(&packet_buffer);
 }
 
 void dram_vrcg_enable(dram_dev_t *dram,
                       dfi_buffer_dev_t *dfi_buffer,
-                      dfi_command_cfg_t *cfg)
+                      dram_freq_cfg_t *cfg)
 {
     dram->mr13 |= VRCG__MSK;
     dram_write_mode_register_13(dram, dfi_buffer, cfg, dram->mr13);
@@ -161,34 +109,15 @@ void dram_vrcg_enable(dram_dev_t *dram,
 
 void dram_vrcg_disable(dram_dev_t *dram,
                        dfi_buffer_dev_t *dfi_buffer,
-                       dfi_command_cfg_t *cfg)
+                       dram_freq_cfg_t *cfg)
 {
     dram->mr13 &= ~VRCG__MSK;
     dram_write_mode_register_13(dram, dfi_buffer, cfg, dram->mr13);
 }
 
-static void dram_write_mode_register(__UNUSED__ dram_dev_t *dram,
-                                 dfi_buffer_dev_t *dfi_buffer,
-                                 dfi_command_cfg_t *cfg,
-                                 uint8_t mr,
-                                 uint8_t op)
-{
-    dfi_tx_packet_buffer_t packet_buffer;
-    command_t command[2] = {0};
-    command[0].command_type = COMMAND_TYPE_CKE;
-
-    create_write_mode_register_command(&command[1], CS_0, mr, op);
-
-    dfi_tx_packet_buffer_init(&packet_buffer);
-    dfi_tx_packet_buffer_fill(&command[1], &packet_buffer, cfg, 1);
-    dfi_tx_packet_buffer_fill(&command[0], &packet_buffer, cfg, 1);
-    dfi_buffer_fill_and_send_packets(dfi_buffer, &packet_buffer.list);
-    dfi_tx_packet_buffer_free(&packet_buffer);
-}
-
 void dram_write_mode_register_13(dram_dev_t *dram,
                                  dfi_buffer_dev_t *dfi_buffer,
-                                 dfi_command_cfg_t *cfg,
+                                 dram_freq_cfg_t *cfg,
                                  uint8_t mr13)
 {
     dram->mr13 = mr13;
@@ -197,7 +126,7 @@ void dram_write_mode_register_13(dram_dev_t *dram,
 
 void dram_write_mode_register_2(dram_dev_t *dram,
                                 dfi_buffer_dev_t *dfi_buffer,
-                                dfi_command_cfg_t *cfg,
+                                dram_freq_cfg_t *cfg,
                                 uint8_t mr2)
 {
     dram->mr2 = mr2;
@@ -223,47 +152,17 @@ void dram_get_write_data_offset_timing(dram_freq_cfg_t *dram_cfg,
     *offset = (dram_cfg->phy_wr_lat + dram_cfg->phy_wr_en + CA_LAST);
 }
 
-void dfi_command_config_init(dram_freq_cfg_t *dram_cfg,
-                             dfi_command_cfg_t *cfg,
-                             burst_length_t bl)
+static void dram_write_mode_register(__UNUSED__ dram_dev_t *dram,
+                                 dfi_buffer_dev_t *dfi_buffer,
+                                 dram_freq_cfg_t *cfg,
+                                 uint8_t mr,
+                                 uint8_t op)
 {
-    cfg->ratio = dram_cfg->ratio;
+    dfi_tx_packet_buffer_t packet_buffer;
 
-    uint8_t burst_length = bl == BL_16 ? 16 : 32;
-
-    // READ
-    cfg->group_offsets[COMMAND_TYPE_READ][PACKET_GROUP_RDDATA_EN] = (dram_cfg->phy_rd_en + CA_LAST);
-    cfg->group_lengths[COMMAND_TYPE_READ][PACKET_GROUP_RDDATA_EN] = burst_length;
-    cfg->group_offsets[COMMAND_TYPE_READ][PACKET_GROUP_RDDATA_CS] = (dram_cfg->phy_rd_en + CA_LAST);
-    cfg->group_lengths[COMMAND_TYPE_READ][PACKET_GROUP_RDDATA_CS] = burst_length;
-    cfg->group_lengths[COMMAND_TYPE_READ][PACKET_GROUP_COMMAND_CKE] = burst_length + dram_cfg->phy_rd_en + CA_LAST;
-    cfg->group_lengths[COMMAND_TYPE_READ][PACKET_GROUP_COMMAND_DCE] = burst_length + dram_cfg->phy_rd_en + CA_LAST;
-
-    // WRITE
-    cfg->group_offsets[COMMAND_TYPE_WRITE][PACKET_GROUP_WRDATA_EN] = (dram_cfg->phy_wr_lat + CA_LAST);
-    cfg->group_lengths[COMMAND_TYPE_WRITE][PACKET_GROUP_WRDATA_EN] = burst_length + 4; // Why??
-    cfg->group_offsets[COMMAND_TYPE_WRITE][PACKET_GROUP_WRDATA] = (dram_cfg->phy_wr_lat + dram_cfg->phy_wr_en + CA_LAST);
-    cfg->group_lengths[COMMAND_TYPE_WRITE][PACKET_GROUP_WRDATA] = burst_length;
-    cfg->group_lengths[COMMAND_TYPE_WRITE][PACKET_GROUP_COMMAND_CKE] = burst_length + dram_cfg->phy_wr_lat +
-                                                                       dram_cfg->phy_wr_en + CA_LAST;
-    cfg->group_lengths[COMMAND_TYPE_WRITE][PACKET_GROUP_COMMAND_DCE] = burst_length + dram_cfg->phy_wr_lat +
-                                                                       dram_cfg->phy_wr_en + CA_LAST;
-
-    // CBT
-    // TODO: Need to update these magic numbers. Timing is wrong here anyway.
-    // NOTE: Length is function of phases so need to double length based on ratio
-    cfg->group_offsets[COMMAND_TYPE_CBT][PACKET_GROUP_WRDATA_EN] = dram_cfg->t_sh_train;
-    cfg->group_lengths[COMMAND_TYPE_CBT][PACKET_GROUP_WRDATA_EN] = 2 * cfg->ratio; // Pulses of DQS
-    cfg->group_offsets[COMMAND_TYPE_CBT][PACKET_GROUP_WRDATA] = dram_cfg->phy_wr_en - 2; // subtract Preamble
-    cfg->group_lengths[COMMAND_TYPE_CBT][PACKET_GROUP_WRDATA] = (2 * dram_cfg->t_sh_train + 4) * cfg->ratio; // Pulses of DQ
-    // Now CA / CS is after for training purposes
-    cfg->group_offsets[COMMAND_TYPE_CBT][PACKET_GROUP_COMMAND] = dram_cfg->phy_wr_en - 2 + dram_cfg->t_vref_ca_long +
-                                                                 (2 * dram_cfg->t_sh_train + 4) * cfg->ratio;
-    cfg->group_offsets[COMMAND_TYPE_CBT][PACKET_GROUP_COMMAND_CS] = dram_cfg->phy_wr_en - 2 + dram_cfg->t_vref_ca_long +
-                                                                    (2 * dram_cfg->t_sh_train + 4) * cfg->ratio;
-    cfg->group_lengths[COMMAND_TYPE_CBT][PACKET_GROUP_COMMAND] = 4;
-    cfg->group_lengths[COMMAND_TYPE_CBT][PACKET_GROUP_COMMAND_CS] = 4;
-    cfg->group_lengths[COMMAND_TYPE_CBT][PACKET_GROUP_COMMAND_DCE] = dram_cfg->phy_wr_en - 2 +
-                                                                     (2 * dram_cfg->t_sh_train + 4) * cfg->ratio +
-                                                                     dram_cfg->t_vref_ca_long + 4;
+    dfi_tx_packet_buffer_init(&packet_buffer);
+    create_mrw_packet_sequence(&packet_buffer, cfg->ratio, CS_0, mr, op, 1);
+    create_cke_packet_sequence(&packet_buffer, 1);
+    dfi_buffer_fill_and_send_packets(dfi_buffer, &packet_buffer.list);
+    dfi_tx_packet_buffer_free(&packet_buffer);
 }

--- a/drivers/dfi/buffer_driver.c
+++ b/drivers/dfi/buffer_driver.c
@@ -115,6 +115,23 @@ void dfi_buffer_send_packets_reg_if(dfi_buffer_dev_t *dfi_buffer)
     reg_write(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR, reg_val);
 }
 
+void dfi_buffer_send_packets_non_blocking_reg_if(dfi_buffer_dev_t *dfi_buffer)
+{
+    uint32_t reg_val;
+    // Send packets
+    dfi_buffer_set_mode_reg_if(dfi_buffer, true);
+
+    do
+    {
+        reg_val = reg_read(dfi_buffer->base + DDR_DFICH_TOP_STA__ADR);
+    } while (GET_REG_FIELD(reg_val, DDR_DFICH_TOP_STA_IG_STATE) != DFI_FIFO_STATE_EMPTY);
+
+    // Disable Timestamp comparison logic
+    reg_val = reg_read(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR);
+    reg_val = UPDATE_REG_FIELD(reg_val, DDR_DFICH_TOP_1_CFG_TS_ENABLE, 0x0);
+    reg_write(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR, reg_val);
+}
+
 static void dfi_buffer_push_packet_into_fifo_reg_if(dfi_buffer_dev_t *dfi_buffer)
 {
     uint32_t reg_val;

--- a/include/dev/dfi/buffer_device.h
+++ b/include/dev/dfi/buffer_device.h
@@ -7,13 +7,14 @@
 #define _DFI_BUFFER_DEV_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <error.h>
 #include <dfi/packet.h>
 #include <kernel/completion.h>
 
 #define DFI_FIFO_DEPTH          (64)
-#define DFI_IG_FIFO_LOAD_NUM    (sizeof(dfi_tx_packet_t) / sizeof(uint32_t))
-#define DFI_EG_FIFO_LOAD_NUM    (sizeof(dfi_rx_packet_t) / sizeof(uint32_t))
+#define DFI_IG_FIFO_LOAD_NUM    (TX_PACKET_SIZE_WORDS)
+#define DFI_EG_FIFO_LOAD_NUM    (RX_PACKET_SIZE_WORDS)
 
 /**
  * @brief DFI FIFO State
@@ -97,13 +98,17 @@ wddr_return_t dfi_buffer_fill_packets(dfi_buffer_dev_t *dfi_buffer,
 /**
  * @brief   DFI Buffer Send Packets
  *
- * @details Sends the packets in the IG FIFO.
+ * @details Sends the packets in the IG FIFO. Can choose to block task or not.
  *
- * @param[in]   dfi_buffer  pointer to DFI Buffer device.
+ * @note    should_block must be false if calling this function from an
+ *          interrupt context.
+ *
+ * @param[in]   dfi_buffer      pointer to DFI Buffer device.
+ * @param[in]   should_block    flag to indicate if task should be blocked.
  *
  * @return      void
  */
-void dfi_buffer_send_packets(dfi_buffer_dev_t *dfi_buffer);
+void dfi_buffer_send_packets(dfi_buffer_dev_t *dfi_buffer, bool should_block);
 
 /**
  * @brief   DFI Buffer Fill and Send Packets

--- a/include/dev/dfi/command.h
+++ b/include/dev/dfi/command.h
@@ -111,7 +111,6 @@ typedef struct command_data_t
 typedef struct command_t
 {
     command_type_t  command_type;
-    chipselect_t    cs;
     command_frame_t address[MAX_COMMAND_FRAMES];
     command_data_t  *data;
 } command_t;

--- a/include/dev/dram/device.h
+++ b/include/dev/dram/device.h
@@ -44,36 +44,24 @@ void dram_init(dram_dev_t *dram);
  *
  * @details Performs a Power Down sequence for DRAM using DFI Buffer.
  *
- * @note    cfg parameter must be initialized for current frequency prior to
- *          calling this function.
- *
  * @param[in]   dram            pointer to DRAM device.
  * @param[in]   dfi_buffer      pointer to DFI Buffer device.
- * @param[in]   cfg             pointer to DFI Command Configuration.
  *
  * @return      void
  */
-void dram_power_down(dram_dev_t *dram,
-                     dfi_buffer_dev_t *dfi_buffer,
-                     dfi_command_cfg_t *cfg);
+void dram_power_down(dram_dev_t *dram, dfi_buffer_dev_t *dfi_buffer);
 
 /**
  * @brief   DRAM Idle
  *
  * @details Puts DRAM into IDLE state using DFI Buffer.
  *
- * @note    cfg parameter must be initialized for current frequency prior to
- *          calling this function.
- *
  * @param[in]   dram            pointer to DRAM device.
  * @param[in]   dfi_buffer      pointer to DFI Buffer device.
- * @param[in]   cfg             pointer to DFI Command Configuration.
  *
  * @return      void
  */
-void dram_idle(dram_dev_t *dram,
-               dfi_buffer_dev_t *dfi_buffer,
-               dfi_command_cfg_t *cfg);
+void dram_idle(dram_dev_t *dram, dfi_buffer_dev_t *dfi_buffer);
 
 /**
  * @brief   DRAM Frequency Innitialization
@@ -81,12 +69,9 @@ void dram_idle(dram_dev_t *dram,
  * @details Initializes DRAM for a given frequency by writing required Mode
  *          Register values.
  *
- * @note    cfg parameter must be initialized for current frequency prior to
- *          calling this function.
  *
  * @param[in]   dram            pointer to DRAM device.
  * @param[in]   dfi_buffer      pointer to DFI Buffer device.
- * @param[in]   cfg             pointer to DFI Command Configuration.
  * @param[in]   dram_cfg        pointer to DRAM Frequency Configuration data.
  * @param[in]   dram_cal        pointer to DRAM Frequency Calibration data.
  *
@@ -94,7 +79,6 @@ void dram_idle(dram_dev_t *dram,
  */
 void dram_frequency_init(dram_dev_t *dram,
                          dfi_buffer_dev_t *dfi_buffer,
-                         dfi_command_cfg_t *cfg,
                          dram_freq_cfg_t *dram_cfg,
                          dram_freq_cal_t *dram_cal);
 
@@ -108,13 +92,13 @@ void dram_frequency_init(dram_dev_t *dram,
  *
  * @param[in]   dram            pointer to DRAM device.
  * @param[in]   dfi_buffer      pointer to DFI Buffer device.
- * @param[in]   cfg             pointer to DFI Command Configuration.
+ * @param[in]   cfg             pointer to DRAM Frequency Configuration data.
  *
  * @return      void
  */
 void dram_cbt_enter(dram_dev_t *dram,
                     dfi_buffer_dev_t *dfi_buffer,
-                    dfi_command_cfg_t *cfg);
+                    dram_freq_cfg_t *cfg);
 
 /**
  * @brief   DRAM Command Bus Training (CBT) Exit
@@ -126,68 +110,61 @@ void dram_cbt_enter(dram_dev_t *dram,
  *
  * @param[in]   dram            pointer to DRAM device.
  * @param[in]   dfi_buffer      pointer to DFI Buffer device.
- * @param[in]   cfg             pointer to DFI Command Configuration.
+ * @param[in]   cfg             pointer to DRAM Frequency Configuration data.
  *
  * @return      void
  */
 void dram_cbt_exit(dram_dev_t *dram,
                    dfi_buffer_dev_t *dfi_buffer,
-                   dfi_command_cfg_t *cfg);
+                   dram_freq_cfg_t *cfg);
 
 /**
  * @brief   DRAM Vref Current Generator(VRCG) Enable
  *
  * @details Enables VRCG in DRAM using DFI Buffer.
  *
- * @note    cfg parameter must be initialized for current frequency prior to
- *          calling this function.
  *
  * @param[in]   dram            pointer to DRAM device.
  * @param[in]   dfi_buffer      pointer to DFI Buffer device.
- * @param[in]   cfg             pointer to DFI Command Configuration.
+ * @param[in]   cfg             pointer to DRAM Frequency Configuration data.
  *
  * @return      void
  */
 void dram_vrcg_enable(dram_dev_t *dram,
                       dfi_buffer_dev_t *dfi_buffer,
-                      dfi_command_cfg_t *cfg);
+                      dram_freq_cfg_t *cfg);
 
 /**
  * @brief   DRAM Vref Current Generator(VRCG) Disable
  *
  * @details Disables VRCG in DRAM using DFI Buffer.
  *
- * @note    cfg parameter must be initialized for current frequency prior to
- *          calling this function.
  *
  * @param[in]   dram            pointer to DRAM device.
  * @param[in]   dfi_buffer      pointer to DFI Buffer device.
- * @param[in]   cfg             pointer to DFI Command Configuration.
+ * @param[in]   cfg             pointer to DRAM Frequency Configuration data.
  *
  * @return      void
  */
 void dram_vrcg_disable(dram_dev_t *dram,
                        dfi_buffer_dev_t *dfi_buffer,
-                       dfi_command_cfg_t *cfg);
+                       dram_freq_cfg_t *cfg);
 
 /**
  * @brief   DRAM Write Mode Register 13
  *
  * @details Sets the value of Mode Register 13 in DRAM using DFI Buffer.
  *
- * @note    cfg parameter must be initialized for current frequency prior to
- *          calling this function.
- *
  * @param[in]   dram            pointer to DRAM device.
  * @param[in]   dfi_buffer      pointer to DFI Buffer device.
- * @param[in]   cfg             pointer to DFI Command Configuration.
+ * @param[in]   cfg             pointer to DRAM Frequency Configuration data.
  * @param[in]   mr13            the value of MR13 to set.
  *
  * @return      void
  */
 void dram_write_mode_register_13(dram_dev_t *dram,
                                  dfi_buffer_dev_t *dfi_buffer,
-                                 dfi_command_cfg_t *cfg,
+                                 dram_freq_cfg_t *cfg,
                                  uint8_t mr13);
 
 /**
@@ -195,19 +172,16 @@ void dram_write_mode_register_13(dram_dev_t *dram,
  *
  * @details Sets the value of Mode Register 2 in DRAM using DFI Buffer.
  *
- * @note    cfg parameter must be initialized for current frequency prior to
- *          calling this function.
- *
  * @param[in]   dram            pointer to DRAM device.
  * @param[in]   dfi_buffer      pointer to DFI Buffer device.
- * @param[in]   cfg             pointer to DFI Command Configuration.
+ * @param[in]   cfg             pointer to DRAM Frequency Configuration data.
  * @param[in]   mr13            the value of MR2 to set.
  *
  * @return      void
  */
 void dram_write_mode_register_2(dram_dev_t *dram,
                                 dfi_buffer_dev_t *dfi_buffer,
-                                dfi_command_cfg_t *cfg,
+                                dram_freq_cfg_t *cfg,
                                 uint8_t mr2);
 
 /**
@@ -251,22 +225,5 @@ void dram_get_write_enable_offset_timing(dram_freq_cfg_t *dram_cfg,
  */
 void dram_get_write_data_offset_timing(dram_freq_cfg_t *dram_cfg,
                                        uint8_t *offset);
-
-/**
- * @brief    DFI Command Config Intialization
- *
- * @details Helper function to initialize DFI Command Configuration based on
- *          DRAM Frequency Configuration. This creates correct timing for all
- *          DFI Commands and DFI Packet Groups.
- *
- * @param[in]   dram_cfg    pointer to DRAM Freuency Configuration
- * @param[in]   cfg         pointer to DFI Command Configuration.
- * @param[in]   bl          burst length to use for this configuration
- *
- * @return      void
- */
-void dfi_command_config_init(dram_freq_cfg_t *dram_cfg,
-                             dfi_command_cfg_t *cfg,
-                             burst_length_t bl);
 
 #endif /* _DRAM_DEV_H_ */

--- a/include/dev/wddr/phy_defs.h
+++ b/include/dev/wddr/phy_defs.h
@@ -175,9 +175,9 @@ typedef enum wddr_msr_t
  */
 typedef enum wddr_freq_ratio_t
 {
-    WDDR_FREQ_RATIO_1TO1 = 1,
-    WDDR_FREQ_RATIO_1TO2 = 2,
-    WDDR_FREQ_RATIO_1TO4 = 4,
+    WDDR_FREQ_RATIO_1TO1 = 0,
+    WDDR_FREQ_RATIO_1TO2 = 1,
+    WDDR_FREQ_RATIO_1TO4 = 2,
 } wddr_freq_ratio_t;
 
 #endif /* _WDDR_PHY_DEFS_H_ */

--- a/include/drivers/dfi/buffer_driver.h
+++ b/include/drivers/dfi/buffer_driver.h
@@ -73,16 +73,30 @@ void dfi_buffer_set_wdata_hold_reg_if(dfi_buffer_dev_t *dfi_buffer, bool enable)
 /**
  * @brief   DFI Buffer Send Packets Register Interface
  *
- * @details Enables logic to send packets from IG FIFO. This function blocks
- *          until the IG FIFO is empty. If IG FIFO is arleady empty, then
- *          function returns immediately. This function turns on and leaves
- *          Buffer Mode enabled after returning.
+ * @details Enables logic to send packets from IG FIFO. This function will put
+ *          current thread to sleep until the IG FIFO is empty.
+ *          If IG FIFO is arleady empty, then function returns immediately.
+ *          This function turns on and leaves Buffer Mode enabled.
  *
  * @param[in]   dfi_buffer  pointer to DFI Buffer device.
  *
  * @return      void
  */
 void dfi_buffer_send_packets_reg_if(dfi_buffer_dev_t *dfi_buffer);
+
+/**
+ * @brief   DFI Buffer Send Packets (Non-Blocking) Register Interface
+ *
+ * @details Enables logic to send packets from IG FIFO. This function blocks
+ *          (via polling) until the IG FIFO is empty. If IG FIFO is arleady
+ *          empty, then function returns immediately. This function turns on
+ *          and leaves Buffer Mode enabled.
+ *
+ * @param[in]   dfi_buffer  pointer to DFI Buffer device.
+ *
+ * @return      void
+ */
+void dfi_buffer_send_packets_non_blocking_reg_if(dfi_buffer_dev_t *dfi_buffer);
 
 /**
  * @brief   DFI Buffer Write IG FIFO Register Interface


### PR DESCRIPTION
Fixes:
  - None

Features:
  - Added a non-blocking version of sending packets via
    DFI Buffer to be used in interrupt context
  - Simplified logic for creating packet sequences to
    be written to DFI Buffer
  - Added support for Tx Packet Buffer to use a storage
    pool to allocate packets instead of malloc
  - DRAM device updated to use new DFI Packet API
  - Updated WDDR_FREQ_RATIO enumerations to remove need
    for dividing to determine required number of packets