### PR TITLE
Frequency Switch Support

### DIFF
--- a/dev/wddr/device.c
+++ b/dev/wddr/device.c
@@ -3,10 +3,17 @@
  *
  * SPDX-License-Identifier: GPL-3.0
  */
+
+/* Standard includes. */
 #include <stdint.h>
 #include <string.h>
+#include <stdbool.h>
+
+/* Kernel includes. */
 #include <kernel/io.h>
 #include <dfi/driver.h>
+
+/* LPDDR includes. */
 #include <driver/driver.h>
 #include <driver/cmn_driver.h>
 #include <fsw/driver.h>
@@ -29,19 +36,38 @@
 #include <wddr/notification_map.h>
 
 /*******************************************************************************
+**                           VARIABLE DECLARATIONS
+*******************************************************************************/
+packet_item_t packets[20] __attribute__ ((section (".data"))) = {0};
+
+/*******************************************************************************
 **                            FUNCTION DECLARATIONS
 *******************************************************************************/
 /** @brief   Internal Notification Handler */
 static void notification_handler(Notification_t notification, void *args);
 
+/** @brief  Internal Common WDDR Frequency Switch Implementation */
+static wddr_return_t wddr_freq_switch_prv(wddr_dev_t *wddr, uint8_t freq_id, wddr_msr_t msr, bool sw_switch);
+
 /** @brief  Internal Frequency Switch Function */
-static wddr_return_t wddr_sw_freq_switch(wddr_dev_t *wddr, uint8_t freq_id);
+static wddr_return_t wddr_sw_freq_switch(wddr_dev_t *wddr, uint8_t freq_id, wddr_msr_t msr);
 
 /** @brief  Internal Function to enable all PHY LPDEs and Phase Interpolators */
 static void wddr_enable(wddr_dev_t *wddr);
 
 /** @brief  Internal Function to flush DFI interfaces using DFI Buffer */
-static void wddr_dfi_buffer_flush(wddr_dev_t *wddr);
+static void wddr_dfi_buffer_flush(dfi_buffer_dev_t *dfi_buffer);
+
+/**
+ * @brief   WDDR DFI Buffer Prime
+ *
+ * @details Internal Function to prime DFI interface for smooth hand-offs
+ *          during frequency switch.
+ */
+static void wddr_dfi_buffer_prime(dfi_buffer_dev_t *dfi_buffer);
+
+/** @brief  Internal Function to prepare MRW updates for frequency switch */
+static void wddr_prep_freq_switch_mrw_update(dfi_buffer_dev_t *dfi_buffer, dram_freq_cfg_t *cfg);
 
 /** @brief  Internal Function to clear FIFO for all channels */
 static void wddr_clear_fifo_all_channels(wddr_dev_t *wddr);
@@ -54,6 +80,13 @@ static void wddr_iocal_update_csr(void *dev);
 
 /** @brief  Internal Function passed to DFI Update FSM performing IOCAL Cal */
 static void wddr_iocal_calibrate(void *dev);
+
+/** @brief  Init Complete Callback. Sends MRWs for next frequency during switch. */
+static void wddr_init_complete_callback(fs_fsm_t *fsm, void *args);
+
+/*******************************************************************************
+**                              IMPLEMENTATIONS
+*******************************************************************************/
 
 void wddr_init(wddr_dev_t *wddr, uint32_t base, wddr_table_t *table)
 {
@@ -101,11 +134,14 @@ wddr_return_t wddr_boot(wddr_dev_t *wddr)
 {
     uint8_t current_vco_id;
 
-    // Calibrate Boot frequency
+    // Calibrate all frequencies
     #ifdef CONFIG_CALIBRATE_PLL
-    pll_calibrate_vco(&wddr->pll,
-                      &wddr->table->cal.freq[WDDR_PHY_BOOT_FREQ].pll,
-                      &wddr->table->cfg.freq[WDDR_PHY_BOOT_FREQ].pll);
+    for (uint8_t freq_id = 0; freq_id < WDDR_PHY_VALID_FREQ_NUM; freq_id++)
+    {
+        pll_calibrate_vco(&wddr->pll,
+                          &wddr->table->cal.freq[freq_id].pll,
+                          &wddr->table->cfg.freq[freq_id].pll);
+    }
     #endif
 
     /**
@@ -129,7 +165,7 @@ wddr_return_t wddr_boot(wddr_dev_t *wddr)
     }
 
     // Switch to PHY_BOOT Frequency
-    PROPAGATE_ERROR(wddr_sw_freq_switch(wddr, WDDR_PHY_BOOT_FREQ));
+    PROPAGATE_ERROR(wddr_sw_freq_switch(wddr, WDDR_PHY_BOOT_FREQ, WDDR_MSR_0));
 
     // Turn on LPDE / Phase Interpolators in PHY
     wddr_enable(wddr);
@@ -138,7 +174,7 @@ wddr_return_t wddr_boot(wddr_dev_t *wddr)
     wddr_clear_fifo_all_channels(wddr);
     fsw_csp_sync_reg_if();
     wddr_configure_phy(wddr, WDDR_PHY_BOOT_FREQ, WDDR_MSR_0);
-    wddr_dfi_buffer_flush(wddr);
+    wddr_dfi_buffer_flush(&wddr->dfi.dfi_buffer);
     wddr_clear_fifo_all_channels(wddr);
 
     // Release override of CS / CKE TX Drivers
@@ -214,13 +250,20 @@ wddr_return_t wddr_boot(wddr_dev_t *wddr)
         wddr_set_chip_select_reg_if(wddr, channel, WDDR_RANK_0, false);
     } // Channel loop
 
+    // Prime DFI buffer
+    wddr_dfi_buffer_prime(&wddr->dfi.dfi_buffer);
+    wddr_clear_fifo_all_channels(wddr);
+
     // Switch VCOs until on VCO_INDEX_PHY_1
     pll_fsm_get_current_vco_id(&wddr->fsm.pll, &current_vco_id);
     while (current_vco_id != VCO_INDEX_PHY_1)
     {
-        PROPAGATE_ERROR(wddr_sw_freq_switch(wddr, WDDR_PHY_BOOT_FREQ));
+        PROPAGATE_ERROR(wddr_sw_freq_switch(wddr, WDDR_PHY_BOOT_FREQ, WDDR_MSR_0));
         pll_fsm_get_current_vco_id(&wddr->fsm.pll, &current_vco_id);
     }
+
+    // Register init_complete callback
+    freq_switch_register_init_complete_callback(&wddr->fsm.fsw, wddr_init_complete_callback, wddr);
 
     // Switch to HW frequency switch mode
     PROPAGATE_ERROR(freq_switch_event_hw_switch_mode(&wddr->fsm.fsw));
@@ -228,10 +271,38 @@ wddr_return_t wddr_boot(wddr_dev_t *wddr)
     return WDDR_SUCCESS;
 }
 
-static wddr_return_t wddr_sw_freq_switch(wddr_dev_t *wddr, uint8_t freq_id)
+wddr_return_t wddr_prep_switch(wddr_dev_t *wddr, uint8_t freq_id)
+{
+    uint32_t reg_val;
+    uint8_t next_msr;
+
+    if (freq_id >= WDDR_PHY_FREQ_NUM ||
+        !wddr->table->valid[freq_id])
+    {
+        return WDDR_ERROR;
+    }
+
+    // Get next MSR
+    reg_val = reg_read(WDDR_MEMORY_MAP_FSW + DDR_FSW_CTRL_STA__ADR);
+    next_msr = !GET_REG_FIELD(reg_val, DDR_FSW_CTRL_STA_CMN_MSR);
+
+    // Configure PHY
+    wddr_configure_phy(wddr, freq_id, next_msr);
+
+    // Prepare MRW sequence in DFI Buffer
+    wddr_prep_freq_switch_mrw_update(&wddr->dfi.dfi_buffer,
+                                     &wddr->table->cfg.freq[freq_id].dram);
+
+    // Prep PLL for a switch
+    PROPAGATE_ERROR(wddr_freq_switch_prv(wddr, freq_id, next_msr, false));
+
+    return WDDR_SUCCESS;
+}
+
+static wddr_return_t wddr_freq_switch_prv(wddr_dev_t *wddr, uint8_t freq_id, wddr_msr_t msr, bool sw_switch)
 {
     fs_prep_data_t fs_prep_data = {
-        .msr = WDDR_MSR_0,
+        .msr = msr,
         .prep_data = {
             .freq_id = freq_id,
             .cal = &wddr->table->cal.freq[freq_id].pll,
@@ -241,7 +312,7 @@ static wddr_return_t wddr_sw_freq_switch(wddr_dev_t *wddr, uint8_t freq_id)
 
     vReInitCompletion(&wddr->fsw_event);
 
-    freq_switch_event_prep(&wddr->fsm.fsw, &fs_prep_data);
+    PROPAGATE_ERROR(freq_switch_event_prep(&wddr->fsm.fsw, &fs_prep_data));
 
     // Ensure FSM is in WAIT_FOR_SWITCH state before performing switch
     vWaitForCompletion(&wddr->fsw_event);
@@ -252,17 +323,25 @@ static wddr_return_t wddr_sw_freq_switch(wddr_dev_t *wddr, uint8_t freq_id)
     }
 
     // Perform frequency switch
-    freq_switch_event_sw_switch(&wddr->fsm.fsw);
-
-    // Wait for switch to complete
-    vWaitForCompletion(&wddr->fsw_event);
-    configASSERT(wddr->fsm.fsw.fsm.current_state == FS_STATE_IDLE);
-    if (wddr->fsm.fsw.fsm.current_state != FS_STATE_IDLE)
+    if (sw_switch)
     {
-        return WDDR_ERROR;
+        PROPAGATE_ERROR(freq_switch_event_sw_switch(&wddr->fsm.fsw));
+
+        // Wait for switch to complete
+        vWaitForCompletion(&wddr->fsw_event);
+        configASSERT(wddr->fsm.fsw.fsm.current_state == FS_STATE_IDLE);
+        if (wddr->fsm.fsw.fsm.current_state != FS_STATE_IDLE)
+        {
+            return WDDR_ERROR;
+        }
     }
 
     return WDDR_SUCCESS;
+}
+
+static wddr_return_t wddr_sw_freq_switch(wddr_dev_t *wddr, uint8_t freq_id, wddr_msr_t msr)
+{
+    return wddr_freq_switch_prv(wddr, freq_id, msr, true);
 }
 
 static void notification_handler(Notification_t notification, void *args)
@@ -288,7 +367,7 @@ static void wddr_enable(wddr_dev_t *wddr)
     }
 }
 
-static void wddr_dfi_buffer_flush(wddr_dev_t *wddr)
+static void wddr_dfi_buffer_flush(dfi_buffer_dev_t *dfi_buffer)
 {
     /**
      * @note    For boot procedure, all DFI signals need to be flushed. To do
@@ -335,7 +414,77 @@ static void wddr_dfi_buffer_flush(wddr_dev_t *wddr)
     vListInsertEnd(&packet_list, &packets[1].list_item);
 
     // Send packets to initialize buffer for first time
-    dfi_buffer_fill_and_send_packets(&wddr->dfi.dfi_buffer, &packet_list);
+    dfi_buffer_fill_and_send_packets(dfi_buffer, &packet_list);
+
+    // Must disable buffer when done
+    dfi_buffer_disable(dfi_buffer);
+}
+static void wddr_dfi_buffer_prime(dfi_buffer_dev_t *dfi_buffer)
+{
+    dfi_tx_packet_buffer_t buffer;
+
+    // Prime DFI buffer with CKE sequence
+    dfi_tx_packet_buffer_init(&buffer);
+    create_cke_packet_sequence(&buffer, 1);
+    create_cke_packet_sequence(&buffer, 10);
+    dfi_buffer_fill_and_send_packets(dfi_buffer, &buffer.list);
+
+    // Free packets
+    dfi_tx_packet_buffer_free(&buffer);
+
+    // Must disable buffer when done
+    dfi_buffer_disable(dfi_buffer);
+}
+
+static void wddr_prep_freq_switch_mrw_update(dfi_buffer_dev_t *dfi_buffer, dram_freq_cfg_t *cfg)
+{
+    dfi_tx_packet_buffer_t packet_buffer;
+    packet_storage_t storage = {
+        .packets = packets,
+        .len = 20,
+        .index = 0,
+    };
+
+    // Initialize TX Packet Buffer
+    dfi_tx_packet_buffer_init(&packet_buffer);
+    packet_buffer.storage = &storage;
+
+    // Allocate and Initialize
+    for (uint8_t j = 0; j < storage.len; j++)
+    {
+        for (uint8_t i = 0; i < TX_PACKET_SIZE_WORDS; i--)
+        {
+            storage.packets[j].packet.raw_data[i] = 0;
+        }
+    }
+
+    create_cke_packet_sequence(&packet_buffer, 1);
+
+    for (uint8_t rank = CS_0; rank < WDDR_PHY_RANK; rank++)
+    {
+        create_mrw_packet_sequence(&packet_buffer, cfg->ratio, rank, 0x01, cfg->mr1, 10);
+        create_cke_packet_sequence(&packet_buffer, 1);
+        create_mrw_packet_sequence(&packet_buffer, cfg->ratio, rank, 0x02, cfg->mr2, 10);
+        create_cke_packet_sequence(&packet_buffer, 1);
+        create_mrw_packet_sequence(&packet_buffer, cfg->ratio, rank, 0x0B, cfg->mr11, 10);
+        create_cke_packet_sequence(&packet_buffer, 1);
+    }
+
+    // Prefill packets
+    dfi_buffer_fill_packets(dfi_buffer, &packet_buffer.list);
+
+    /**
+     * @note: No need to call dfi_tx_packet_buffer_free since packet_buffer
+     *        is created on the stack and won't be reused.
+     */
+}
+
+static void wddr_init_complete_callback(__UNUSED__ fs_fsm_t *fsm, void *args)
+{
+    wddr_dev_t *wddr = (wddr_dev_t *) args;
+
+    // Send MRW from DFI Buffer
+    dfi_buffer_send_packets(&wddr->dfi.dfi_buffer, false);
 
     // Must disable buffer when done
     dfi_buffer_disable(&wddr->dfi.dfi_buffer);

--- a/drivers/dfi/buffer_driver.c
+++ b/drivers/dfi/buffer_driver.c
@@ -11,31 +11,6 @@
 #include <kernel/completion.h>
 
 /**
- * @brief   DFI Buffer Push Packet Into FIFO Register Interface
- *
- * @details Pushes a packet from the Loader HW into the FIFO.
- *
- * @param[in]   dfi_buffer  pointer to DFI Buffer device.
- *
- * @return      void
- */
-static void dfi_buffer_push_packet_into_fifo_reg_if(dfi_buffer_dev_t *dfi_buffer);
-
-/**
- * @brief   DFI Buffer Pops Packet From FIFO Register Interface
- *
- * @details Pops a packet from the FIFO into the loader HW.
- *
- * @param[in]   dfi_buffer  pointer to DFI Buffer device.
- *
- * @return      returns whether data was popped from EG FIFO.
- * @retval      WDDR_SUCCESS if data was popped.
- * @retval      WDDR_ERROR_DFI_PACKET_FIFO_EMPTY if no data was popped.
- * @retval      WDDR_ERROR otherwise.
- */
-static wddr_return_t dfi_buffer_pop_packet_from_fifo_reg_if(dfi_buffer_dev_t *dfi_buffer);
-
-/**
  * @brief   DFI Ingress Buffer IRQ Handler
  *
  * @details Handles coordination of tasks related to DFI Ingress Buffer IRQ.
@@ -132,21 +107,11 @@ void dfi_buffer_send_packets_non_blocking_reg_if(dfi_buffer_dev_t *dfi_buffer)
     reg_write(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR, reg_val);
 }
 
-static void dfi_buffer_push_packet_into_fifo_reg_if(dfi_buffer_dev_t *dfi_buffer)
-{
-    uint32_t reg_val;
-    uint8_t upd_bit;
-    reg_val = reg_read(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR);
-    upd_bit = GET_REG_FIELD(reg_val, DDR_DFICH_TOP_1_CFG_WDATA_UPDATE) ^ 0x1;
-    reg_val = UPDATE_REG_FIELD(reg_val, DDR_DFICH_TOP_1_CFG_WDATA_UPDATE, upd_bit);
-    reg_write(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR, reg_val);
-}
-
 wddr_return_t dfi_buffer_write_ig_fifo_reg_if(dfi_buffer_dev_t *dfi_buffer,
                                               uint32_t data[DFI_IG_FIFO_LOAD_NUM])
 {
     uint32_t reg_val;
-    uint8_t en_bit;
+    uint8_t en_bit, upd_bit;
 
     reg_val = reg_read(dfi_buffer->base + DDR_DFICH_TOP_STA__ADR);
 
@@ -156,17 +121,23 @@ wddr_return_t dfi_buffer_write_ig_fifo_reg_if(dfi_buffer_dev_t *dfi_buffer,
         return WDDR_ERROR_DFI_PACKET_FIFO_FULL;
     }
 
+    // Get WDATA ENABLE status
+    reg_val = reg_read(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR);
+
     // Write entire packet and push
     for (uint8_t ii = DFI_IG_FIFO_LOAD_NUM; ii > 0; ii--)
     {
         reg_write(dfi_buffer->base + DDR_DFICH_IG_DATA_CFG__ADR, data[ii - 1]);
-        reg_val = reg_read(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR);
         en_bit = GET_REG_FIELD(reg_val, DDR_DFICH_TOP_1_CFG_WDATA_ENABLE) ^ 0x1;
         reg_val = UPDATE_REG_FIELD(reg_val, DDR_DFICH_TOP_1_CFG_WDATA_ENABLE, en_bit);
         reg_write(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR, reg_val);
     }
 
-    dfi_buffer_push_packet_into_fifo_reg_if(dfi_buffer);
+    // Push packet into the FIFO
+    upd_bit = GET_REG_FIELD(reg_val, DDR_DFICH_TOP_1_CFG_WDATA_UPDATE) ^ 0x1;
+    reg_val = UPDATE_REG_FIELD(reg_val, DDR_DFICH_TOP_1_CFG_WDATA_UPDATE, upd_bit);
+    reg_write(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR, reg_val);
+
     return WDDR_SUCCESS;
 }
 
@@ -174,39 +145,29 @@ wddr_return_t dfi_buffer_read_eg_fifo_reg_if(dfi_buffer_dev_t *dfi_buffer,
                                              uint32_t data[DFI_EG_FIFO_LOAD_NUM])
 {
     uint32_t reg_val;
-    uint8_t en_bit;
+    uint8_t en_bit, upd_bit;
 
-    // Pop a packet
-    PROPAGATE_ERROR(dfi_buffer_pop_packet_from_fifo_reg_if(dfi_buffer));
-
-    // Write into data buffer
-    for (uint8_t ii = 0; ii < DFI_EG_FIFO_LOAD_NUM; ii++)
-    {
-        data[ii] = reg_read(dfi_buffer->base + DDR_DFICH_EG_DATA_STA__ADR);
-        reg_val = reg_read(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR);
-        en_bit = GET_REG_FIELD(reg_val, DDR_DFICH_TOP_1_CFG_RDATA_ENABLE) ^ 0x1;
-        reg_val = UPDATE_REG_FIELD(reg_val, DDR_DFICH_TOP_1_CFG_RDATA_ENABLE, en_bit);
-        reg_write(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR, reg_val);
-    }
-
-    return WDDR_SUCCESS;
-}
-
-static wddr_return_t dfi_buffer_pop_packet_from_fifo_reg_if(dfi_buffer_dev_t *dfi_buffer)
-{
-    uint32_t reg_val;
-    uint8_t upd_bit;
-
+    // FIFO can't be empty
     reg_val = reg_read(dfi_buffer->base + DDR_DFICH_TOP_STA__ADR);
     if (GET_REG_FIELD(reg_val, DDR_DFICH_TOP_STA_EG_STATE) == DFI_FIFO_STATE_EMPTY)
     {
         return WDDR_ERROR_DFI_PACKET_FIFO_EMPTY;
     }
 
+    // Pop a packet
     reg_val = reg_read(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR);
     upd_bit = GET_REG_FIELD(reg_val, DDR_DFICH_TOP_1_CFG_RDATA_UPDATE) ^ 0x1;
     reg_val = UPDATE_REG_FIELD(reg_val, DDR_DFICH_TOP_1_CFG_RDATA_UPDATE, upd_bit);
     reg_write(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR, reg_val);
+
+    // Write into data buffer
+    for (uint8_t ii = 0; ii < DFI_EG_FIFO_LOAD_NUM; ii++)
+    {
+        data[ii] = reg_read(dfi_buffer->base + DDR_DFICH_EG_DATA_STA__ADR);
+        en_bit = GET_REG_FIELD(reg_val, DDR_DFICH_TOP_1_CFG_RDATA_ENABLE) ^ 0x1;
+        reg_val = UPDATE_REG_FIELD(reg_val, DDR_DFICH_TOP_1_CFG_RDATA_ENABLE, en_bit);
+        reg_write(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR, reg_val);
+    }
 
     return WDDR_SUCCESS;
 }

--- a/fsm/freq_switch/fsm.c
+++ b/fsm/freq_switch/fsm.c
@@ -111,7 +111,10 @@ wddr_return_t freq_switch_event_prep(fs_fsm_t *fsm, fs_prep_data_t *prep_data)
     }
 
     // Stop timer if started
-    xTimerStop(fsm->timer, 0);
+    if (xTimerIsTimerActive(fsm->timer))
+    {
+        xTimerStop(fsm->timer, 0);
+    }
 
     // Call into FSM
     fsm_handle_external_event(&fsm->fsm, FS_STATE_PREP_SWITCH, prep_data);
@@ -238,7 +241,7 @@ static void freq_switch_state_switch(fsm_t *fsm, void *data)
     fsw_ctrl_set_msr_vco_ovr_reg_if(true);
 
     // Switch PLL to PHY Frequency
-    pll_fsm_switch_event(pll_fsm);
+    pll_fsm_switch_event(pll_fsm, true);
 
     fsm_handle_internal_event(fsm, FS_STATE_WAIT_FOR_LOCK, fsm);
 }
@@ -290,22 +293,26 @@ static void freq_switch_state_wait_for_lock(fsm_t *fsm, void *data)
     fs_fsm_t *fs_fsm = (fs_fsm_t *) data;
     pll_fsm_t *pll_fsm = (pll_fsm_t *) (fsm->instance);
 
-    // If PLL already locked, go to post switch
+    // If PLL already locked, go to post switch (only happens for SW switch)
     if (pll_fsm->current_state == PLL_STATE_LOCKED)
     {
         // Cancel Watchdog Timer
         xTimerStop(fs_fsm->timer, 0);
 
         fsm_handle_internal_event(fsm, FS_STATE_POST_SWITCH, NULL);
+        return;
     }
-    // Start watchdog timer otherwise
-    else
+
+    // Start timer
+    if (xTimerReset(fs_fsm->timer, 0) == pdFALSE)
     {
-        if (xTimerReset(fs_fsm->timer, 0) == pdFALSE)
-        {
-            fsm_handle_internal_event(fsm, FS_STATE_FAIL, NULL);
-            return;
-        }
+        fsm_handle_internal_event(fsm, FS_STATE_FAIL, NULL);
+    }
+
+    // Let PLL know that HW switch happened
+    if (pll_fsm->current_state == PLL_STATE_PREP_DONE)
+    {
+        pll_fsm_switch_event(pll_fsm, false);
     }
 }
 
@@ -417,7 +424,8 @@ static void pll_state_change_cb(__UNUSED__ fsm_t *pll_fsm, uint8_t state, void *
         fsm_handle_external_event(&fs_fsm->fsm, FS_STATE_WAIT_FOR_SWITCH, fs_fsm);
     }
     else if (state == PLL_STATE_NOT_LOCKED &&
-             fs_fsm->fsm.current_state != FS_STATE_SWITCH)
+             fs_fsm->fsm.current_state != FS_STATE_SWITCH &&
+             fs_fsm->fsm.current_state != FS_STATE_WAIT_FOR_LOCK)
     {
         fsm_handle_external_event(&fs_fsm->fsm, FS_STATE_FAIL, NULL);
     }

--- a/fsm/pll/fsm.c
+++ b/fsm/pll/fsm.c
@@ -96,6 +96,9 @@ void pll_fsm_prep_event(pll_fsm_t *fsm, pll_prep_data_t *data)
     uint32_t reg_val;
     pll_dev_t *pll = (pll_dev_t *) fsm->instance;
 
+    // Disable interrupts
+    disable_irq(MCU_FAST_IRQ_PLL);
+
     // Disable PLL interrupts
     reg_val = reg_read(pll->base + DDR_MVP_PLL_CORE_STATUS_INT_EN__ADR);
     reg_val = UPDATE_REG_FIELD(reg_val, DDR_MVP_PLL_CORE_STATUS_INT_EN_INITIAL_SWITCH_DONE_INT_EN, 0x0);
@@ -106,9 +109,9 @@ void pll_fsm_prep_event(pll_fsm_t *fsm, pll_prep_data_t *data)
     fsm_handle_external_event(fsm, PLL_STATE_PREP, data);
 }
 
-void pll_fsm_switch_event(pll_fsm_t *fsm)
+void pll_fsm_switch_event(pll_fsm_t *fsm, bool is_sw_switch)
 {
-    fsm_handle_external_event(fsm, PLL_STATE_SWITCH, NULL);
+    fsm_handle_external_event(fsm, PLL_STATE_SWITCH, (void *) is_sw_switch);
 }
 
 void pll_fsm_get_current_freq(pll_fsm_t *fsm, uint8_t *freq_id)
@@ -157,8 +160,17 @@ static void pll_fsm_not_locked_state_handler(fsm_t *fsm, __UNUSED__ void *data)
 
 static void pll_fsm_prep_state_handler(fsm_t *fsm, void *data)
 {
+    uint32_t reg_val;
     pll_dev_t *pll = (pll_dev_t *) fsm->instance;
     pll_prep_data_t *prep_data = (pll_prep_data_t *) data;
+
+    // Enable Initial Lock interrupt
+    // This should be here so don't miss initial switch doen event when HW / SW switch happens
+    reg_val = reg_read(pll->base + DDR_MVP_PLL_CORE_STATUS_INT_EN__ADR);
+    reg_val = UPDATE_REG_FIELD(reg_val, DDR_MVP_PLL_CORE_STATUS_INT_EN_INITIAL_SWITCH_DONE_INT_EN, 0x1);
+    reg_val = UPDATE_REG_FIELD(reg_val, DDR_MVP_PLL_CORE_STATUS_INT_EN_CORE_LOCKED_INT_EN, 0x0);
+    reg_val = UPDATE_REG_FIELD(reg_val, DDR_MVP_PLL_CORE_STATUS_INT_EN_LOSS_OF_LOCK_INT_EN, 0x0);
+    reg_write(pll->base + DDR_MVP_PLL_CORE_STATUS_INT_EN__ADR, reg_val);
 
     // Prepare PLL and VCO for switch
     pll_prepare_vco_switch(pll, prep_data->freq_id, prep_data->cal, prep_data->cfg);
@@ -169,29 +181,17 @@ static void pll_fsm_prep_state_handler(fsm_t *fsm, void *data)
 
 static void pll_fsm_prep_done_state_handler(fsm_t *fsm, void *data)
 {
-    uint32_t reg_val;
-    pll_dev_t *pll = (pll_dev_t *) fsm->instance;
-
-    // Enable Initial Lock interrupt
-    reg_val = reg_read(pll->base + DDR_MVP_PLL_CORE_STATUS_INT_EN__ADR);
-    reg_val = UPDATE_REG_FIELD(reg_val, DDR_MVP_PLL_CORE_STATUS_INT_EN_INITIAL_SWITCH_DONE_INT_EN, 0x1);
-    reg_val = UPDATE_REG_FIELD(reg_val, DDR_MVP_PLL_CORE_STATUS_INT_EN_CORE_LOCKED_INT_EN, 0x0);
-    reg_val = UPDATE_REG_FIELD(reg_val, DDR_MVP_PLL_CORE_STATUS_INT_EN_LOSS_OF_LOCK_INT_EN, 0x0);
-    reg_write(pll->base + DDR_MVP_PLL_CORE_STATUS_INT_EN__ADR, reg_val);
-
-    // Enable interrupt in CPU
-    enable_irq(MCU_FAST_IRQ_PLL);
+    // Do nothing
 }
 
-static void pll_fsm_switch_state_handler(fsm_t *fsm, __UNUSED__ void *data)
+static void pll_fsm_switch_state_handler(fsm_t *fsm, void *data)
 {
     pll_dev_t *pll = (pll_dev_t *) fsm->instance;
-
-    // Disable interrupts
-    disable_irq(MCU_FAST_IRQ_PLL);
+    bool is_sw_switch = (bool) data;
 
     // Switch PLL
-    pll_switch_vco(pll, true);
+    pll_switch_vco(pll, is_sw_switch);
+
     fsm_handle_internal_event(fsm, PLL_STATE_NOT_LOCKED, NULL);
 }
 

--- a/include/dev/messenger/messages_wddr.h
+++ b/include/dev/messenger/messages_wddr.h
@@ -23,4 +23,14 @@ typedef enum messages_wddr_t {
     MESSAGE_WDDR_END_OF_MESSAGES,
 } messages_wddr_t;
 
+#define WDDR_FREQ_PREP_REQ__FREQ_ID__MSK        (0x000000FF)
+#define WDDR_FREQ_PREP_REQ__FREQ_ID__SHFT       (0x00000000)
+
+#define WDDR_FREQ_PREP_RSP__STATUS__MSK         (0x000000FF)
+#define WDDR_FREQ_PREP_RSP__STATUS__SHFT        (0x00000000)
+#define WDDR_FREQ_PREP_RSP__FREQ_ID__MSK        (0x0000FF00)
+#define WDDR_FREQ_PREP_RSP__FREQ_ID__SHFT       (0x00000008)
+#define WDDR_FREQ_PREP_RSP__RESP_CODE__MSK      (0x00FF0000)
+#define WDDR_FREQ_PREP_RSP__RESP_CODE__SHFT     (0x00000010)
+
 #endif /* _MESSAGES_WDDR_H_ */

--- a/include/dev/wddr/device.h
+++ b/include/dev/wddr/device.h
@@ -110,5 +110,18 @@ void wddr_init(wddr_dev_t *wddr, uint32_t base, wddr_table_t *table);
  */
 wddr_return_t wddr_boot(wddr_dev_t *wddr);
 
+/**
+ * @brief   Wavious DDR (WDDR) Prep Switch
+ *
+ * @details Prepares WDDR device for a frequency switch.
+ *
+ * @param[in]   wddr    pointer to WDDR device.
+ * @param[in]   freq_id ID of frequency to prepare.
+ *
+ * @return      returns whether prep completed successfully.
+ * @retval      WDDR_SUCCESS if successful.
+ * @retval      WDDR_ERROR otherwise.
+ */
+wddr_return_t wddr_prep_switch(wddr_dev_t *wddr, uint8_t freq_id);
 
 #endif /* _WDDR_DEV_H_ */

--- a/include/fsm/pll/fsm.h
+++ b/include/fsm/pll/fsm.h
@@ -76,11 +76,13 @@ void pll_fsm_prep_event(pll_fsm_t *fsm, pll_prep_data_t *data);
  *
  * @details Switches PLL VCO. Only valid to call if FSM is in PREP state.
  *
- * @param[in]   fsm         pointer to PLL FSM.
+ * @param[in]   fsm             pointer to PLL FSM.
+ * @param[in]   is_sw_switch    flag to indicate if SW switch.
+ *                              false indicates HW switched PLL VCOs.
  *
  * @return      void
  */
-void pll_fsm_switch_event(pll_fsm_t *fsm);
+void pll_fsm_switch_event(pll_fsm_t *fsm, bool is_sw_switch);
 
 /**
  * @brief   PLL FSM Current Frequency


### PR DESCRIPTION
Fixes:
  - Fixed issue where PLL VCO wasn't being swapped
    when using HW Frequency Switch

Features:
  - WDDR Frequency Switch Support
  - WDDR Application that supports frequency switch requests via
    Message Interface
  - PLL calibration for all frequencies