### PR TITLE
DFI and Driver Fixes

### DIFF
--- a/dev/dfi/packet.c
+++ b/dev/dfi/packet.c
@@ -80,7 +80,7 @@ wddr_return_t create_ck_packet_sequence(dfi_tx_packet_buffer_t *buffer,
     packet->packet.packet.dce_p2 = 1;
     packet->packet.packet.dce_p3 = 1;
     packet->packet.packet.time = time_offset;
-    buffer->ts_last_packet = time_offset - 1;
+    buffer->ts_last_packet = time_offset;
 
     // Add to list
     vListInitialiseItem(&packet->list_item);
@@ -112,7 +112,7 @@ wddr_return_t create_cke_packet_sequence(dfi_tx_packet_buffer_t *buffer,
     packet->packet.packet.cke_p2 = DFI_PACK_CKE_VAL;
     packet->packet.packet.cke_p3 = DFI_PACK_CKE_VAL;
     packet->packet.packet.time = time_offset;
-    buffer->ts_last_packet = time_offset - 1;
+    buffer->ts_last_packet = time_offset;
 
     // Add to list
     vListInitialiseItem(&packet->list_item);
@@ -175,11 +175,14 @@ static void create_packet(dfi_tx_packet_buffer_t *buffer, packet_item_t **packet
     }
     else
     {
-        new_packet = pvPortMalloc(sizeof(packet_item_t));
-        // Intialize packet
-        for (uint8_t i = 0; i < TX_PACKET_SIZE_WORDS; i--)
+        new_packet = (packet_item_t *) pvPortMalloc(sizeof(packet_item_t));
+        if (new_packet != NULL)
         {
-            new_packet->packet.raw_data[i] = 0;
+            // Intialize packet
+            for (uint8_t i = 0; i < TX_PACKET_SIZE_WORDS; i++)
+            {
+                new_packet->packet.raw_data[i] = 0;
+            }
         }
     }
 

--- a/dev/driver/device.c
+++ b/dev/driver/device.c
@@ -37,7 +37,7 @@ void driver_set_impedance_all_bits(driver_dev_t *driver,
             num_bits = WDDR_PHY_DQ_SLICE_NUM;
             break;
         case WDDR_SLICE_TYPE_DQS:
-            num_bits = WDDR_PHY_DQS_SLICE_NUM;
+            num_bits = WDDR_PHY_DQS_TXRX_SLICE_NUM;
             break;
         case WDDR_SLICE_TYPE_CA:
             num_bits = WDDR_PHY_CA_SLICE_NUM;

--- a/dev/wddr/device.c
+++ b/dev/wddr/device.c
@@ -452,7 +452,7 @@ static void wddr_prep_freq_switch_mrw_update(dfi_buffer_dev_t *dfi_buffer, dram_
     // Allocate and Initialize
     for (uint8_t j = 0; j < storage.len; j++)
     {
-        for (uint8_t i = 0; i < TX_PACKET_SIZE_WORDS; i--)
+        for (uint8_t i = 0; i < TX_PACKET_SIZE_WORDS; i++)
         {
             storage.packets[j].packet.raw_data[i] = 0;
         }

--- a/include/dev/dfi/table.h
+++ b/include/dev/dfi/table.h
@@ -120,7 +120,7 @@ typedef union dfi_clken_pext_cfg_t
  * sel_dq_rd   sets override fro DQ read path.
  * val_dq_rd   override value for DQ read path (only applies if sel = 1).
  */
-typedef struct dfi_ovr_traffic_cfg_t
+typedef union dfi_ovr_traffic_cfg_t
 {
     struct
     {


### PR DESCRIPTION
Fixes
  - Correctly set last packet timestamp for CK and CKE packets
  - Add checks ensuring new packet allocated successfully before initializing
  - Initialize packet raw data values correctly
  - Use correct value for DQS slice bits
  - Fix union definition for DFI OVR Traffic Cfg

Features
  - None