### PR TITLE
WDDR Training

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,9 @@ message("ZQCAL CAL:     ${CONFIG_CALIBRATE_ZQCAL}")
 set(CONFIG_CALIBRATE_SA true CACHE BOOL "Flag to indicate if SA calibration is performed at boot.")
 message("SA CAL:        ${CONFIG_CALIBRATE_SA}")
 
+# Set flag for skipping DRAM training at boot
+set(CONFIG_DRAM_TRAIN false CACHE BOOL "Flag to indicate if DRAM training is performed at boot.")
+message("DRAM_TRAIN:    ${CONFIG_DRAM_TRAIN}")
 ################################################################################
 ##                        SOURCE DIRECTORIES
 ################################################################################/

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ make
 | CONFIG_CALIBRATE_PLL     |    true        | Enables PLL calibration at boot       |
 | CONFIG_CALIBRATE_ZQCAL   |    true        | Enables ZQCAL calibration at boot     |
 | CONFIG_CALIBRATE_SA      |    true        | Enables Sense Amp calibration at boot |
+| CONFIG_DRAM_TRAIN        |    true        | Enables DRAM Training at boot         |
 
 #### Changing Configurations
 It is recommended that all binaries are built with the default configuration. However,
@@ -84,8 +85,22 @@ After running the commands given in the [Building](#building) section of this do
 the configuration can be updated as follows:
 ~~~~
 cd build
-cmake .. -DCONFIG_CALIBRATE_PLL=<true|false> -DCONFIG_CALIBRATE_ZQCAL=<true|false> -DCONFIG_CALIBRATE_SA=<true|false>
+cmake .. -DCONFIG_CALIBRATE_PLL=<true|false> -DCONFIG_CALIBRATE_ZQCAL=<true|false> -DCONFIG_CALIBRATE_SA=<true|false> -DCONFIG_DRAM_TRAIN=<true|false>
 make
 ~~~~
 
 The generic command: `cmake .. -D<CMAKE_VARIABLE_NAME>=<VAL>`
+
+### Adding Extended Functionality to Builds
+In order to allow for extended capabilites not required for PHY functionality
+(such as training), an interface library was added to the WDDR device, named
+wddr_ext. In order to utilize this library, you can add additional source and
+include files to this library to be included when building the WDDR device
+library. This will enable external functions to be added to the build to
+override weak functions within the WDDR device (such as wddr_train).
+
+## DRAM Training
+Currently, the WDDR device includes the necessary hooks to perform DRAM training
+during boot of the PHY, but the algorithms are not included in this release.
+These algorithms can be added using the wddr_ext interface library. If training
+is a requirement of your application, contact Wavious for support.

--- a/configure
+++ b/configure
@@ -7,6 +7,7 @@ BUILD_TYPE=""
 CONFIG_CAL_PLL="true"
 CONFIG_CAL_ZQCAL="true"
 CONFIG_CAL_SA="true"
+CONFIG_DRAM_TRAIN="false"
 
 # Common build prep function
 init_build_common() {
@@ -22,6 +23,7 @@ init_lpddr() {
            -DCONFIG_CALIBRATE_PLL=${CONFIG_CAL_PLL} \
            -DCONFIG_CALIBRATE_ZQCAL=${CONFIG_CAL_ZQCAL} \
            -DCONFIG_CALIBRATE_SA=${CONFIG_CAL_SA} \
+           -DCONFIG_DRAM_TRAIN=${CONFIG_DRAM_TRAIN} \
            -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
   cd ..
 }
@@ -34,6 +36,7 @@ echo "-t, --build_type <Debug | Release>"
 echo "--no-pll-cal      (disables PLL calibration)"
 echo "--no-zqcal-cal    (disables ZQCAL calibration)"
 echo "--no-sa-cal       (disables SA calibration)"
+echo "--dram-train      (enables DRAM training at boot)"
 }
 
 PARAMS=""
@@ -53,6 +56,10 @@ while [ $# -gt 0 ]; do
       ;;
      --no-sa-cal)
       CONFIG_CAL_SA="false"
+      shift 1
+      ;;
+     --dram-train)
+      CONFIG_DRAM_TRAIN="true"
       shift 1
       ;;
     -h | --help)

--- a/dev/dfi/command.c
+++ b/dev/dfi/command.c
@@ -131,6 +131,7 @@ static void create_write_frame(command_frame_t frame[MAX_COMMAND_FRAMES],
                                uint8_t ap,
                                uint8_t bl)
 {
+    bl = bl == BL_32 ? 1 : 0;
     // Update CA Pins for this command
     frame[0].ca_pins = WR_1_CA_PINS | bl << 5;
     frame[1].ca_pins = (0x3 & bank_address) | ((column_address & 0x80) >> 3) | (ap << 5); //  BA2:0 | V | C9 | AP

--- a/dev/dfi/packet.c
+++ b/dev/dfi/packet.c
@@ -8,15 +8,16 @@
 #include <dfi/packet.h>
 
 #define DFI_PACK_CKE_VAL        ((WDDR_PHY_RANK << 1) - 1)
+#define CMD_PHASE_PER_CYC_SHFT  (0)
+#define DATA_PHASE_PER_CYC_SHFT (1)
 
 /** @brief  Internal Function for creating a new packet_item_t instance */
 static void create_packet(dfi_tx_packet_buffer_t *buffer, packet_item_t **packet);
 
-/** @brief  Internal Function for creating sequence of packets to send command to DRAM */
-static wddr_return_t create_address_packet_sequence(dfi_tx_packet_buffer_t *buffer,
-                                                    wddr_freq_ratio_t ratio,
-                                                    command_t *command,
-                                                    uint16_t time_offset);
+/** @brief  Internal Function for determining phase mask to fill packets */
+static uint32_t determine_group_mask(packet_group_info_t *group_info,
+                                     uint8_t cycles_per_packet,
+                                     uint8_t phases_per_cycle_shft);
 
 /** @brief  Internal Function for extracting data from a packet and storing in a data buffer */
 static void extract_packet_data(dfi_rx_packet_desc_t *packet,
@@ -62,23 +63,30 @@ void dfi_rx_packet_buffer_init(dfi_rx_packet_buffer_t *buffer)
     memset(buffer, 0, sizeof(dfi_rx_packet_buffer_t));
 }
 
-
-
-wddr_return_t create_ck_packet_sequence(dfi_tx_packet_buffer_t *buffer,
+packet_item_t * create_ck_packet_sequence(dfi_tx_packet_buffer_t *buffer,
                                         uint16_t time_offset)
 {
     packet_item_t *packet;
     create_packet(buffer, &packet);
     if (packet == NULL)
     {
-        return WDDR_ERROR;
+        return NULL;
     }
 
     time_offset += buffer->ts_last_packet;
     packet->packet.packet.dce_p0 = 1;
     packet->packet.packet.dce_p1 = 1;
+#if WDDR_PHY_MAX_FREQ_RATIO >= WDDR_FREQ_RATIO_1TO2
     packet->packet.packet.dce_p2 = 1;
     packet->packet.packet.dce_p3 = 1;
+#endif
+#if WDDR_PHY_MAX_FREQ_RATIO == WDDR_FREQ_RATIO_1TO4
+    packet->packet.packet.dce_p4 = 1;
+    packet->packet.packet.dce_p5 = 1;
+    packet->packet.packet.dce_p6 = 1;
+    packet->packet.packet.dce_p7 = 1;
+#endif
+
     packet->packet.packet.time = time_offset;
     buffer->ts_last_packet = time_offset;
 
@@ -89,51 +97,231 @@ wddr_return_t create_ck_packet_sequence(dfi_tx_packet_buffer_t *buffer,
     listSET_LIST_ITEM_OWNER(&packet->list_item, packet);
     vListInsertEnd(&buffer->list, &packet->list_item);
 
-    return WDDR_SUCCESS;
+    return packet;
 }
 
-wddr_return_t create_cke_packet_sequence(dfi_tx_packet_buffer_t *buffer,
+packet_item_t * create_cke_packet_sequence(dfi_tx_packet_buffer_t *buffer,
                                          uint16_t time_offset)
 {
     packet_item_t *packet;
-    create_packet(buffer, &packet);
+    packet = create_ck_packet_sequence(buffer, time_offset);
     if (packet == NULL)
     {
-        return WDDR_ERROR;
+        return NULL;
     }
 
-    time_offset += buffer->ts_last_packet;
-    packet->packet.packet.dce_p0 = 1;
-    packet->packet.packet.dce_p1 = 1;
-    packet->packet.packet.dce_p2 = 1;
-    packet->packet.packet.dce_p3 = 1;
     packet->packet.packet.cke_p0 = DFI_PACK_CKE_VAL;
     packet->packet.packet.cke_p1 = DFI_PACK_CKE_VAL;
+#if WDDR_PHY_MAX_FREQ_RATIO >= WDDR_FREQ_RATIO_1TO2
     packet->packet.packet.cke_p2 = DFI_PACK_CKE_VAL;
     packet->packet.packet.cke_p3 = DFI_PACK_CKE_VAL;
-    packet->packet.packet.time = time_offset;
-    buffer->ts_last_packet = time_offset;
-
-    // Add to list
-    vListInitialiseItem(&packet->list_item);
-    packet->packet.packet.time = time_offset;
-    listSET_LIST_ITEM_VALUE(&packet->list_item, time_offset);
-    listSET_LIST_ITEM_OWNER(&packet->list_item, packet);
-    vListInsertEnd(&buffer->list, &packet->list_item);
-
-    return WDDR_SUCCESS;
+#endif
+#if WDDR_PHY_MAX_FREQ_RATIO == WDDR_FREQ_RATIO_1TO4
+    packet->packet.packet.cke_p4 = DFI_PACK_CKE_VAL;
+    packet->packet.packet.cke_p5 = DFI_PACK_CKE_VAL;
+    packet->packet.packet.cke_p6 = DFI_PACK_CKE_VAL;
+    packet->packet.packet.cke_p7 = DFI_PACK_CKE_VAL;
+#endif
+    return packet;
 }
 
-wddr_return_t create_mrw_packet_sequence(dfi_tx_packet_buffer_t *buffer,
-                                        wddr_freq_ratio_t ratio,
-                                        chipselect_t cs,
-                                        uint8_t mode_register,
-                                        uint8_t op,
-                                        uint16_t time_offset)
+void fill_address_packet(packet_item_t *packet,
+                         packet_group_info_t *group_info,
+                         uint8_t cycles_per_packet,
+                         command_t *command,
+                         uint16_t phase_length)
 {
-    command_t command = {0};
-    create_write_mode_register_command(&command, cs, mode_register, op);
-    return create_address_packet_sequence(buffer, ratio, &command, time_offset);
+    uint32_t mask = determine_group_mask(group_info,
+                                         cycles_per_packet,
+                                         CMD_PHASE_PER_CYC_SHFT);
+
+    uint16_t phase_offset = phase_length - group_info->phase_remaining;
+
+    if (mask & 0x1)
+    {
+        packet->packet.packet.cs_p0 = command->address[phase_offset].cs;
+        packet->packet.packet.cs_p1 = command->address[phase_offset].cs;
+        packet->packet.packet.address_p0 = command->address[phase_offset].ca_pins;
+        group_info->phase_remaining -= 1;
+        phase_offset++;
+    }
+#if WDDR_PHY_MAX_FREQ_RATIO >= WDDR_FREQ_RATIO_1TO2
+    if (mask & 0x2)
+    {
+        packet->packet.packet.cs_p2 = command->address[phase_offset].cs;
+        packet->packet.packet.cs_p3 = command->address[phase_offset].cs;
+        packet->packet.packet.address_p2 = command->address[phase_offset].ca_pins;
+        group_info->phase_remaining -= 1;
+        phase_offset++;
+    }
+#endif
+#if WDDR_PHY_MAX_FREQ_RATIO == WDDR_FREQ_RATIO_1TO4
+    if (mask & 0x4)
+    {
+        packet->packet.packet.cs_p4 = command->address[phase_offset].cs;
+        packet->packet.packet.cs_p5 = command->address[phase_offset].cs;
+        packet->packet.packet.address_p4 = command->address[phase_offset].ca_pins;
+        group_info->phase_remaining -= 1;
+        phase_offset++;
+    }
+    if (mask & 0x8)
+    {
+        packet->packet.packet.cs_p6 = command->address[phase_offset].cs;
+        packet->packet.packet.cs_p7 = command->address[phase_offset].cs;
+        packet->packet.packet.address_p6 = command->address[phase_offset].ca_pins;
+        group_info->phase_remaining -= 1;
+        phase_offset++;
+    }
+#endif
+}
+
+void fill_wrdata_en_packet(packet_item_t *packet,
+                           packet_group_info_t *group_info,
+                           uint8_t cycles_per_packet)
+{
+    uint32_t mask = determine_group_mask(group_info,
+                                         cycles_per_packet,
+                                         DATA_PHASE_PER_CYC_SHFT);
+
+    if (mask & 0x1)
+    {
+        packet->packet.packet.wrdata_en_p0 = 1;
+        packet->packet.packet.wrdata_en_p1 = 1;
+        group_info->phase_remaining -= 2;
+    }
+#if WDDR_PHY_MAX_FREQ_RATIO >= WDDR_FREQ_RATIO_1TO2
+    if (mask & 0x2)
+    {
+        packet->packet.packet.wrdata_en_p2 = 1;
+        packet->packet.packet.wrdata_en_p3 = 1;
+        group_info->phase_remaining -= 2;
+    }
+#endif
+#if WDDR_PHY_MAX_FREQ_RATIO == WDDR_FREQ_RATIO_1TO4
+    if (mask & 0x4)
+    {
+        packet->packet.packet.wrdata_en_p4 = 1;
+        packet->packet.packet.wrdata_en_p5 = 1;
+        group_info->phase_remaining -= 2;
+    }
+    if (mask & 0x8)
+    {
+        packet->packet.packet.wrdata_en_p6 = 1;
+        packet->packet.packet.wrdata_en_p7 = 1;
+        group_info->phase_remaining -= 2;
+    }
+#endif
+}
+
+void fill_wrdata_packet(packet_item_t *packet,
+                        packet_group_info_t *group_info,
+                        chipselect_t cs,
+                        command_data_t *data,
+                        uint8_t cycles_per_packet,
+                        uint16_t phase_length)
+{
+    uint32_t mask = determine_group_mask(group_info,
+                                         cycles_per_packet,
+                                         DATA_PHASE_PER_CYC_SHFT);
+
+    uint16_t data_offset = phase_length - group_info->phase_remaining;
+
+    if (mask & 0x1)
+    {
+        packet->packet.packet.wrdata_cs_p0  = 1 << cs;
+        packet->packet.packet.dq0_wrdata_p0 = data->dq[0][data_offset];
+        packet->packet.packet.dq1_wrdata_p0 = data->dq[1][data_offset];
+        packet->packet.packet.wrdata_cs_p1  = 1 << cs;
+        packet->packet.packet.dq0_wrdata_p1 = data->dq[0][data_offset + 1];
+        packet->packet.packet.dq1_wrdata_p1 = data->dq[1][data_offset + 1];
+        group_info->phase_remaining -= 2;
+        data_offset += 2;
+    }
+#if WDDR_PHY_MAX_FREQ_RATIO >= WDDR_FREQ_RATIO_1TO2
+    if (mask & 0x2)
+    {
+        packet->packet.packet.wrdata_cs_p2  = 1 << cs;
+        packet->packet.packet.dq0_wrdata_p2 = data->dq[0][data_offset];
+        packet->packet.packet.dq1_wrdata_p2 = data->dq[1][data_offset];
+        packet->packet.packet.wrdata_cs_p3  = 1 << cs;
+        packet->packet.packet.dq0_wrdata_p3 = data->dq[0][data_offset + 1];
+        packet->packet.packet.dq1_wrdata_p3 = data->dq[1][data_offset + 1];
+        group_info->phase_remaining -= 2;
+        data_offset += 2;
+    }
+#endif
+#if WDDR_PHY_MAX_FREQ_RATIO == WDDR_FREQ_RATIO_1TO4
+    if (mask & 0x4)
+    {
+        packet->packet.packet.wrdata_cs_p4  = 1 << cs;
+        packet->packet.packet.dq0_wrdata_p4 = data->dq[0][data_offset];
+        packet->packet.packet.dq1_wrdata_p4 = data->dq[1][data_offset];
+        packet->packet.packet.wrdata_cs_p5  = 1 << cs;
+        packet->packet.packet.dq0_wrdata_p5 = data->dq[0][data_offset + 1];
+        packet->packet.packet.dq1_wrdata_p5 = data->dq[1][data_offset + 1];
+        group_info->phase_remaining -= 2;
+        data_offset += 2;
+    }
+    if (mask & 0x8)
+    {
+        packet->packet.packet.wrdata_cs_p6  = 1 << cs;
+        packet->packet.packet.dq0_wrdata_p6 = data->dq[0][data_offset];
+        packet->packet.packet.dq1_wrdata_p6 = data->dq[1][data_offset];
+        packet->packet.packet.wrdata_cs_p7  = 1 << cs;
+        packet->packet.packet.dq0_wrdata_p7 = data->dq[0][data_offset + 1];
+        packet->packet.packet.dq1_wrdata_p7 = data->dq[1][data_offset + 1];
+        group_info->phase_remaining -= 2;
+        data_offset += 2;
+    }
+#endif
+}
+
+void fill_rddata_packet(packet_item_t *packet,
+                        packet_group_info_t *group_info,
+                        chipselect_t cs,
+                        uint8_t cycles_per_packet)
+{
+    uint32_t mask = determine_group_mask(group_info,
+                                         cycles_per_packet,
+                                         DATA_PHASE_PER_CYC_SHFT);
+
+    if (mask & 0x1)
+    {
+
+        packet->packet.packet.rddata_en_p0 = 1;
+        packet->packet.packet.rddata_en_p1 = 1;
+        packet->packet.packet.rddata_cs_p0 = 1 << cs;
+        packet->packet.packet.rddata_cs_p1 = 1 << cs;
+        group_info->phase_remaining -= 2;
+    }
+#if WDDR_PHY_MAX_FREQ_RATIO >= WDDR_FREQ_RATIO_1TO2
+    if (mask & 0x2)
+    {
+        packet->packet.packet.rddata_en_p2 = 1;
+        packet->packet.packet.rddata_en_p3 = 1;
+        packet->packet.packet.rddata_cs_p2 = 1 << cs;
+        packet->packet.packet.rddata_cs_p3 = 1 << cs;
+        group_info->phase_remaining -= 2;
+    }
+#endif
+#if WDDR_PHY_MAX_FREQ_RATIO == WDDR_FREQ_RATIO_1TO4
+    if (mask & 0x4)
+    {
+        packet->packet.packet.rddata_en_p4 = 1;
+        packet->packet.packet.rddata_en_p5 = 1;
+        packet->packet.packet.rddata_cs_p4 = 1 << cs;
+        packet->packet.packet.rddata_cs_p5 = 1 << cs;
+        group_info->phase_remaining -= 2;
+    }
+    if (mask & 0x8)
+    {
+        packet->packet.packet.rddata_en_p6 = 1;
+        packet->packet.packet.rddata_en_p7 = 1;
+        packet->packet.packet.rddata_cs_p6 = 1 << cs;
+        packet->packet.packet.rddata_cs_p7 = 1 << cs;
+        group_info->phase_remaining -= 2;
+    }
+#endif
 }
 
 void dfi_rx_packet_buffer_data_compare(dfi_rx_packet_buffer_t *buffer,
@@ -191,62 +379,6 @@ static void create_packet(dfi_tx_packet_buffer_t *buffer, packet_item_t **packet
     *packet = new_packet;
 }
 
-static wddr_return_t create_address_packet_sequence(dfi_tx_packet_buffer_t *buffer,
-                                                    wddr_freq_ratio_t ratio,
-                                                    command_t *command,
-                                                    uint16_t time_offset)
-{
-    uint8_t phase_offset = 0;
-    uint8_t num_packets = (MAX_COMMAND_FRAMES >> ratio);
-    // Five packets required for this command
-    packet_item_t *packet;
-
-    time_offset += buffer->ts_last_packet;
-
-    for (uint8_t i = 0; i < num_packets; i++)
-    {
-        create_packet(buffer, &packet);
-        if (packet == NULL)
-        {
-            return WDDR_ERROR;
-        }
-
-        packet->packet.packet.dce_p0 = 1;
-        packet->packet.packet.dce_p1 = 1;
-        packet->packet.packet.dce_p2 = 1;
-        packet->packet.packet.dce_p3 = 1;
-        packet->packet.packet.cke_p0 = DFI_PACK_CKE_VAL;
-        packet->packet.packet.cke_p1 = DFI_PACK_CKE_VAL;
-        packet->packet.packet.cke_p2 = DFI_PACK_CKE_VAL;
-        packet->packet.packet.cke_p3 = DFI_PACK_CKE_VAL;
-
-        // Command
-        packet->packet.packet.cs_p0 = command->address[phase_offset].cs;
-        packet->packet.packet.cs_p1 = command->address[phase_offset].cs;
-        packet->packet.packet.address_p0 = command->address[phase_offset].ca_pins;
-        phase_offset++;
-
-        if (ratio == WDDR_FREQ_RATIO_1TO2)
-        {
-            packet->packet.packet.cs_p2 = command->address[phase_offset].cs;
-            packet->packet.packet.cs_p3 = command->address[phase_offset].cs;
-            packet->packet.packet.address_p2 = command->address[phase_offset].ca_pins;
-            phase_offset++;
-        }
-
-        // Add to list
-        vListInitialiseItem(&packet->list_item);
-        packet->packet.packet.time = time_offset;
-        listSET_LIST_ITEM_VALUE(&packet->list_item, time_offset);
-        listSET_LIST_ITEM_OWNER(&packet->list_item, packet);
-        vListInsertEnd(&buffer->list, &packet->list_item);
-        time_offset++;
-    }
-
-    buffer->ts_last_packet = time_offset - 1;
-    return WDDR_SUCCESS;
-}
-
 // TODO: Need to support 8 phases
 static void extract_packet_data(dfi_rx_packet_desc_t *packet,
                                 uint8_t data_packet[PACKET_MAX_NUM_PHASES],
@@ -281,4 +413,30 @@ static bool compare_received_data(uint8_t received[PACKET_MAX_NUM_PHASES],
     }
 
     return true;
+}
+
+void create_packet_group_info(packet_group_info_t *group_info,
+                                     wddr_freq_ratio_t ratio,
+                                     uint16_t dram_clk_cycles,
+                                     uint16_t phase_length)
+{
+    group_info->dfi_ts_start = dram_clk_cycles >> ratio;
+    group_info->cycle_offset = dram_clk_cycles & ((1 << ratio) - 1);
+    group_info->phase_remaining = phase_length;
+}
+
+static uint32_t determine_group_mask(packet_group_info_t *group_info,
+                                     uint8_t cycles_per_packet,
+                                     uint8_t phases_per_cycle_shft)
+{
+    uint16_t cycles_remaining = group_info->phase_remaining >> phases_per_cycle_shft;
+    uint8_t cycle_offset = group_info->cycle_offset;
+    // Cycle offset can only be positive for one mask
+    group_info->cycle_offset = 0;
+    if(cycles_remaining > cycles_per_packet)
+    {
+        cycles_remaining = cycles_per_packet;
+    }
+    uint8_t base_mask = (1 << cycles_remaining) - 1;
+    return (base_mask << cycle_offset) & base_mask;
 }

--- a/dev/dram/device.c
+++ b/dev/dram/device.c
@@ -7,23 +7,85 @@
 #include <compiler.h>
 #include <dram/device.h>
 
-#define CA_LAST         (3)
+#define CS_LOW                  (0)
+#define CS_HIGH                 (1)
+#define CA_CLK_LEN              (3)
+
 #define VRCG__SHFT      (3)
 #define VRCG__MSK       (1 << VRCG__SHFT)
 #define CBT__SHFT       (0)
 #define CBT__MSK        (1 << CBT__SHFT)
+#define FSP_WR__SHFT    (6)
+#define FSP_WR__MSK     (1 << FSP_WR__SHFT)
+#define FSP_OP__SHFT    (7)
+#define FSP_OP__MSK     (1 << FSP_OP__SHFT)
+#define WRLVL__SHFT     (7)
+#define WRLVL__MSK      (1 << WRLVL__SHFT)
 
 /** @brief  Internal Function for updating DRAM Mode Register */
-static void dram_write_mode_register(__UNUSED__ dram_dev_t *dram,
+static void dram_write_mode_register(dram_dev_t *dram,
                                      dfi_buffer_dev_t *dfi_buffer,
-                                     dram_freq_cfg_t *cfg,
                                      uint8_t mr,
                                      uint8_t op);
 
-void dram_init(dram_dev_t *dram)
+/**
+ * @brief   DRAM Create Address Packet Sequence
+ *
+ * @details Creates a sequence of packets for sending commands to DRAM
+ *
+ * @param[in]   buffer          pointer to packet buffer to save packet to.
+ * @param[in]   ratio           ratio of DFI CK to DRAM CK.
+ * @param[in]   command         pointer to command structure to send.
+ * @param[in]   time_offset     time offset from previous packet that the packet
+ *
+ * @return      returns whether packet added to the packet buffer.
+ * @retval      WDDR_SUCCESS if added.
+ * @retval      WDDR_ERROR otherwise.
+ */
+static wddr_return_t dram_create_address_packet_sequence(dfi_tx_packet_buffer_t *buffer,
+                                                         wddr_freq_ratio_t ratio,
+                                                         command_t *command,
+                                                         uint16_t time_offset);
+
+/**
+ * @brief   DRAM Create MRW Packet Sequence
+ *
+ * @details Creates a set of packets in order to send the specified MRW to
+ *          the DRAM.
+ *
+ * @param[in]   buffer          pointer to packet buffer to save packet to.
+ * @param[in]   ratio           ratio of DFI CK to DRAM CK.
+ * @param[in]   cs              chipselect value.
+ * @param[in]   mode_register   which mode reigster number.
+ * @param[in]   op              mode register op data.
+ * @param[in]   time_offset     time offset from previous packet that the packet
+ *                              should be sent.
+ *
+ * @return      returns whether packet added to the packet buffer.
+ * @retval      WDDR_SUCCESS if added.
+ * @retval      WDDR_ERROR otherwise.
+ */
+static wddr_return_t dram_create_mrw_packet_sequence(dfi_tx_packet_buffer_t *buffer,
+                                                     wddr_freq_ratio_t ratio,
+                                                     chipselect_t cs,
+                                                     uint8_t mode_register,
+                                                     uint8_t op,
+                                                     uint16_t time_offset);
+
+void dram_init(dram_dev_t *dram,
+               dram_freq_cfg_t *dram_cfg,
+               dram_freq_cal_t *dram_cal)
 {
     dram->mr13 = 0;
-    dram->mr2 = 0;
+    dram_frequency_set(dram, dram_cfg, dram_cal);
+}
+
+void dram_frequency_set(dram_dev_t *dram,
+                        dram_freq_cfg_t *dram_cfg,
+                        dram_freq_cal_t *dram_cal)
+{
+    dram->cfg = dram_cfg;
+    dram->cal = dram_cal;
 }
 
 void dram_power_down(__UNUSED__ dram_dev_t *dram, dfi_buffer_dev_t *dfi_buffer)
@@ -47,7 +109,7 @@ void dram_idle(__UNUSED__ dram_dev_t *dram, dfi_buffer_dev_t *dfi_buffer)
     dfi_tx_packet_buffer_free(&packet_buffer);
 }
 
-void dram_frequency_init(__UNUSED__ dram_dev_t *dram,
+void dram_frequency_init(dram_dev_t *dram,
                          dfi_buffer_dev_t *dfi_buffer,
                          dram_freq_cfg_t *dram_cfg,
                          dram_freq_cal_t *dram_cal)
@@ -56,26 +118,24 @@ void dram_frequency_init(__UNUSED__ dram_dev_t *dram,
 
     // Initialize TX Packet Buffer
     dfi_tx_packet_buffer_init(&packet_buffer);
-    create_mrw_packet_sequence(&packet_buffer, dram_cfg->ratio, CS_0, 0x1, dram_cfg->mr1, 1);
-    create_mrw_packet_sequence(&packet_buffer, dram_cfg->ratio, CS_0, 0x2, dram_cfg->mr2, 15);
-    create_mrw_packet_sequence(&packet_buffer, dram_cfg->ratio, CS_0, 0xB, dram_cfg->mr11, 15);
-    create_mrw_packet_sequence(&packet_buffer, dram_cfg->ratio, CS_0, 0xC, dram_cal->mr12, 15);
-    create_mrw_packet_sequence(&packet_buffer, dram_cfg->ratio, CS_0, 0xE, dram_cal->mr14, 15);
-    create_cke_packet_sequence(&packet_buffer, 1);
+    dram_prepare_mrw_update(dram, &packet_buffer, dram_cfg, dram_cal);
     dfi_buffer_fill_and_send_packets(dfi_buffer, &packet_buffer.list);
     dfi_tx_packet_buffer_free(&packet_buffer);
+
+    // Update DRAM frequency after sending MRW to ensure previous tables
+    // are used to send MRW.
+    dram_frequency_set(dram, dram_cfg, dram_cal);
 }
 
 void dram_cbt_enter(dram_dev_t *dram,
-                    dfi_buffer_dev_t *dfi_buffer,
-                    dram_freq_cfg_t *cfg)
+                    dfi_buffer_dev_t *dfi_buffer)
 {
     dfi_tx_packet_buffer_t packet_buffer;
 
     dram->mr13 |= CBT__MSK;
 
     dfi_tx_packet_buffer_init(&packet_buffer);
-    create_mrw_packet_sequence(&packet_buffer, cfg->ratio, CS_0, 0xD, dram->mr13, 15);
+    dram_create_mrw_packet_sequence(&packet_buffer, dram->cfg->ratio, CS_0, 0xD, dram->mr13, 15);
     create_cke_packet_sequence(&packet_buffer, 1);
     create_ck_packet_sequence(&packet_buffer, 15);
     dfi_buffer_fill_and_send_packets(dfi_buffer, &packet_buffer.list);
@@ -83,8 +143,7 @@ void dram_cbt_enter(dram_dev_t *dram,
 }
 
 void dram_cbt_exit(dram_dev_t *dram,
-                   dfi_buffer_dev_t *dfi_buffer,
-                   dram_freq_cfg_t *cfg)
+                   dfi_buffer_dev_t *dfi_buffer)
 {
     dfi_tx_packet_buffer_t packet_buffer;
 
@@ -93,76 +152,451 @@ void dram_cbt_exit(dram_dev_t *dram,
     dfi_tx_packet_buffer_init(&packet_buffer);
     create_ck_packet_sequence(&packet_buffer, 15);
     create_cke_packet_sequence(&packet_buffer, 1);
-    create_mrw_packet_sequence(&packet_buffer, cfg->ratio, CS_0, 0xD, dram->mr13, 15);
+    dram_create_mrw_packet_sequence(&packet_buffer, dram->cfg->ratio, CS_0, 0xD, dram->mr13, 15);
     create_cke_packet_sequence(&packet_buffer, 1);
     dfi_buffer_fill_and_send_packets(dfi_buffer, &packet_buffer.list);
     dfi_tx_packet_buffer_free(&packet_buffer);
 }
 
-void dram_vrcg_enable(dram_dev_t *dram,
+void dram_set_fsp_wr(dram_dev_t *dram,
+                     dfi_buffer_dev_t *dfi_buffer,
+                     uint8_t fsp)
+{
+    dram->mr13 &= ~FSP_WR__MSK;
+    dram->mr13 |= (fsp << FSP_WR__SHFT);
+
+    dram_write_mode_register_13(dram, dfi_buffer, dram->mr13);
+}
+
+void dram_set_fsp_op(dram_dev_t *dram,
+                     dfi_buffer_dev_t *dfi_buffer,
+                     uint8_t fsp)
+{
+    dram->mr13 &= ~FSP_OP__MSK & ~FSP_WR__MSK;
+    dram->mr13 |= (fsp << FSP_OP__SHFT) | (fsp << FSP_WR__SHFT);
+
+    dram_write_mode_register_13(dram, dfi_buffer, dram->mr13);
+}
+
+void dram_set_dq_vref(dram_dev_t *dram,
                       dfi_buffer_dev_t *dfi_buffer,
-                      dram_freq_cfg_t *cfg)
+                      uint8_t vref_setting)
+{
+    dram_write_mode_register_14(dram, dfi_buffer, vref_setting);
+}
+
+void dram_wrlvl_enable(dram_dev_t *dram,
+                       dfi_buffer_dev_t *dfi_buffer)
+{
+    dram->cfg->mr2 |= WRLVL__MSK;
+
+    dram_write_mode_register_2(dram, dfi_buffer, dram->cfg->mr2);
+}
+
+void dram_wrlvl_disable(dram_dev_t *dram,
+                        dfi_buffer_dev_t *dfi_buffer)
+{
+    dram->cfg->mr2 &= ~WRLVL__MSK;
+
+    dram_write_mode_register_2(dram, dfi_buffer, dram->cfg->mr2);
+}
+
+void dram_vrcg_enable(dram_dev_t *dram,
+                      dfi_buffer_dev_t *dfi_buffer)
 {
     dram->mr13 |= VRCG__MSK;
-    dram_write_mode_register_13(dram, dfi_buffer, cfg, dram->mr13);
+    dram_write_mode_register_13(dram, dfi_buffer, dram->mr13);
 }
 
 void dram_vrcg_disable(dram_dev_t *dram,
-                       dfi_buffer_dev_t *dfi_buffer,
-                       dram_freq_cfg_t *cfg)
+                       dfi_buffer_dev_t *dfi_buffer)
 {
     dram->mr13 &= ~VRCG__MSK;
-    dram_write_mode_register_13(dram, dfi_buffer, cfg, dram->mr13);
+    dram_write_mode_register_13(dram, dfi_buffer, dram->mr13);
 }
 
 void dram_write_mode_register_13(dram_dev_t *dram,
                                  dfi_buffer_dev_t *dfi_buffer,
-                                 dram_freq_cfg_t *cfg,
                                  uint8_t mr13)
 {
     dram->mr13 = mr13;
-    return dram_write_mode_register(dram, dfi_buffer, cfg, 0xD, dram->mr13);
+    return dram_write_mode_register(dram, dfi_buffer, 0xD, dram->mr13);
+}
+
+void dram_write_mode_register_14(dram_dev_t *dram,
+                                 dfi_buffer_dev_t *dfi_buffer,
+                                 uint8_t mr14)
+{
+    dram->cal->mr14 = mr14;
+    return dram_write_mode_register(dram, dfi_buffer, 0xE, dram->cal->mr14);
 }
 
 void dram_write_mode_register_2(dram_dev_t *dram,
                                 dfi_buffer_dev_t *dfi_buffer,
-                                dram_freq_cfg_t *cfg,
                                 uint8_t mr2)
 {
-    dram->mr2 = mr2;
-    return dram_write_mode_register(dram, dfi_buffer, cfg, 0x2, dram->mr2);
+    dram->cfg->mr2 = mr2;
+    return dram_write_mode_register(dram, dfi_buffer, 0x2, dram->cfg->mr2);
 }
 
 
 void dram_get_read_enable_offset_timing(dram_freq_cfg_t *dram_cfg,
                                         uint8_t *offset)
 {
-    *offset = (dram_cfg->phy_rd_en + CA_LAST);
+    *offset = (dram_cfg->phy_rd_en + CA_CLK_LEN);
 }
 
 void dram_get_write_enable_offset_timing(dram_freq_cfg_t *dram_cfg,
                                          uint8_t *offset)
 {
-    *offset = (dram_cfg->phy_wr_lat + CA_LAST);
+    *offset = (dram_cfg->phy_wr_lat + CA_CLK_LEN);
 }
 
 void dram_get_write_data_offset_timing(dram_freq_cfg_t *dram_cfg,
                                        uint8_t *offset)
 {
-    *offset = (dram_cfg->phy_wr_lat + dram_cfg->phy_wr_en + CA_LAST);
+    *offset = (dram_cfg->phy_wr_lat + dram_cfg->phy_wr_en + CA_CLK_LEN);
 }
 
-static void dram_write_mode_register(__UNUSED__ dram_dev_t *dram,
-                                 dfi_buffer_dev_t *dfi_buffer,
-                                 dram_freq_cfg_t *cfg,
-                                 uint8_t mr,
-                                 uint8_t op)
+wddr_return_t dram_prepare_cbt_sequence(dram_dev_t *dram,
+                               dfi_tx_packet_buffer_t *buffer,
+                               chipselect_t cs,
+                               uint8_t vref_setting,
+                               uint8_t command_address)
+{
+    uint8_t ratio = dram->cfg->ratio;
+    packet_item_t *packet;
+    uint8_t time_offset = 1;
+    uint16_t initial_dram_offset = 0;
+    uint16_t dram_clk = 0;
+    uint16_t wrdata_phases;
+    packet_group_info_t wrdata_en_info, wrdata_info;
+    uint8_t cycles_per_packet = 1 << ratio;
+    uint8_t phases_per_packet = cycles_per_packet << 1;
+    uint8_t data_src[phases_per_packet];
+    command_data_t data = {0};
+    memset(&data_src[0], vref_setting, phases_per_packet);
+    create_data_frame(&data, WDDR_DQ_BYTE_0, &data_src[0], phases_per_packet, 0);
+
+    // Calculate timestamp of first CA packet (time 0).
+    // Shifted by ratio to be measured in DRAM CLK cycles.
+    initial_dram_offset = (buffer->ts_last_packet + time_offset) << ratio;
+
+    create_ck_packet_sequence(buffer, time_offset);
+
+    // First packet group is setting DQ pins to vref_setting
+    dram_clk = initial_dram_offset + cycles_per_packet;
+    // Need to ensure to cover tDStrain offset + 4 phases wrdata_en + 2 extra wrdata packet
+    // Using 2 extra wrdata packets ensures any phase offset is accounted for
+    // Always 2 phases per DRAM cycle, shift left by 1 to account for this
+    wrdata_phases = ((dram->cfg->t_sh_train + (cycles_per_packet << 1)) << 1) + 4;
+    create_packet_group_info(&wrdata_info, ratio, dram_clk, wrdata_phases);
+
+    // Second packet group is toggling DQS tDStrain after setting DQ pins
+    dram_clk += dram->cfg->t_sh_train;
+    create_packet_group_info(&wrdata_en_info, ratio, dram_clk, 4);
+
+    time_offset = wrdata_info.dfi_ts_start - buffer->ts_last_packet;
+    do
+    {
+        packet = create_ck_packet_sequence(buffer, time_offset);
+        if (packet == NULL)
+        {
+            return WDDR_ERROR;
+        }
+
+        if (packet->packet.packet.time >= wrdata_info.dfi_ts_start)
+        {
+            // Use phase_remaining will ensure data sent in only needs to by phases_per_packet long
+            fill_wrdata_packet(packet, &wrdata_info, cs, &data, cycles_per_packet, wrdata_info.phase_remaining);
+        }
+
+        if (packet->packet.packet.time >= wrdata_en_info.dfi_ts_start)
+        {
+            fill_wrdata_en_packet(packet, &wrdata_en_info, cycles_per_packet);
+        }
+
+        time_offset = 1;
+    } while (wrdata_info.phase_remaining >= phases_per_packet);
+
+    // Send CK packet tDHtrain + phy_wr_en after last packet
+    // Add 1 to offset to ensure beyond tDHtrain + phy_wr_en
+    time_offset = ((dram->cfg->t_sh_train + dram->cfg->phy_wr_en) >> ratio) + 1;
+
+    create_ck_packet_sequence(buffer, time_offset);
+
+    // Generate CA data packets to send training sequence
+    time_offset = ((dram->cfg->t_vref_ca_long - dram->cfg->t_sh_train) >> ratio) + 1;
+
+    packet = create_ck_packet_sequence(buffer, time_offset);
+    if (packet == NULL)
+    {
+        return WDDR_ERROR;
+    }
+
+    // Command
+    packet->packet.packet.cs_p0 = CS_HIGH << cs;
+    packet->packet.packet.cs_p1 = CS_HIGH << cs;
+    packet->packet.packet.address_p0 = command_address;
+
+    create_ck_packet_sequence(buffer, 1);
+
+    create_ck_packet_sequence(buffer, 2);
+
+    return WDDR_SUCCESS;
+}
+
+wddr_return_t dram_prepare_wrfifo_sequence(dram_dev_t *dram,
+                                           dfi_tx_packet_buffer_t *buffer,
+                                           burst_length_t burst_length,
+                                           chipselect_t cs,
+                                           uint16_t wrdata_en_offset,
+                                           command_data_t *data)
+{
+    uint16_t initial_dram_offset = 0;
+    uint8_t time_offset = 1;
+    packet_item_t *packet;
+    command_t command = {0};
+    packet_group_info_t wrdata_en_info, wrdata_info;
+
+    // Calculate timestamp of first CA packet (time 0).
+    // Shifted by ratio to be measured in DRAM CLK cycles.
+    initial_dram_offset = (buffer->ts_last_packet + time_offset) << dram->cfg->ratio;
+
+    // Calculate wr latency required for wr packet from time 0
+    // time 0 is identified as first CA packet ts
+    // wrdata offset is measured in DRAM CLKs
+    uint8_t wrdata_en_dram_clk = initial_dram_offset + CA_CLK_LEN + dram->cfg->phy_wr_lat + wrdata_en_offset;
+    uint8_t wrdata_dram_clk = wrdata_en_dram_clk + dram->cfg->phy_wr_en;
+    uint8_t cycles_per_packet = 1 << dram->cfg->ratio;
+
+    create_packet_group_info(&wrdata_en_info, dram->cfg->ratio, wrdata_en_dram_clk, burst_length + 4);
+    create_packet_group_info(&wrdata_info, dram->cfg->ratio, wrdata_dram_clk, burst_length);
+
+    // Create WRFIFO command sequence.
+    create_wrfifo_command(&command, data, cs);
+    dram_create_address_packet_sequence(buffer, dram->cfg->ratio, &command, time_offset);
+
+    time_offset = wrdata_en_info.dfi_ts_start - buffer->ts_last_packet;
+
+    // If enough delay is required, insert CKE packet to keep clocks cycling.
+    if (time_offset > 1)
+    {
+        create_cke_packet_sequence(buffer, 1);
+        time_offset--;
+    }
+
+    do
+    {
+        packet = create_cke_packet_sequence(buffer, time_offset);
+        if (packet == NULL)
+        {
+            return WDDR_ERROR;
+        }
+
+        if (packet->packet.packet.time >= wrdata_en_info.dfi_ts_start)
+        {
+            fill_wrdata_en_packet(packet, &wrdata_en_info, cycles_per_packet);
+        }
+
+        if (packet->packet.packet.time >= wrdata_info.dfi_ts_start)
+        {
+            fill_wrdata_packet(packet, &wrdata_info, cs, data, cycles_per_packet, burst_length);
+        }
+
+        time_offset = 1;
+    } while(wrdata_en_info.phase_remaining || wrdata_info.phase_remaining);
+
+    create_cke_packet_sequence(buffer, 1);
+
+    return WDDR_SUCCESS;
+}
+
+static wddr_return_t dram_prepare_read_sequence(dram_dev_t *dram,
+                                                dfi_tx_packet_buffer_t *buffer,
+                                                burst_length_t burst_length,
+                                                chipselect_t cs,
+                                                uint16_t rddata_en_offset,
+                                                command_t *command)
+{
+    uint16_t initial_dram_offset = 0;
+    packet_item_t *packet;
+    packet_group_info_t rddata_info;
+    uint16_t time_offset = 1;
+
+    // Calculate timestamp of first CA packet (time 0)
+    initial_dram_offset = (buffer->ts_last_packet + time_offset) << dram->cfg->ratio;
+
+    // Calculate rddata offset required for rd packet from time 0
+    // time 0 is identified as first CA packet ts
+    // rddata offset is measured in DRAM CLKs
+    uint8_t rddata_dram_clk = initial_dram_offset + CA_CLK_LEN + dram->cfg->phy_rd_en + rddata_en_offset;
+    uint8_t cycles_per_packet = 1 << dram->cfg->ratio;
+
+    create_packet_group_info(&rddata_info, dram->cfg->ratio, rddata_dram_clk, burst_length);
+
+    dram_create_address_packet_sequence(buffer, dram->cfg->ratio, command, time_offset);
+
+    // Need to add phy_rd_en to get next packet offset.
+    time_offset = rddata_info.dfi_ts_start - buffer->ts_last_packet;
+
+    // If enough delay is required, insert CKE packet to keep clocks cycling.
+    if (time_offset > 1)
+    {
+        create_cke_packet_sequence(buffer, 1);
+        time_offset--;
+    }
+
+    do
+    {
+        packet = create_cke_packet_sequence(buffer, time_offset);
+        if (packet == NULL)
+        {
+            return WDDR_ERROR;
+        }
+
+        fill_rddata_packet(packet, &rddata_info, cs, cycles_per_packet);
+
+        time_offset = 1;
+    } while (rddata_info.phase_remaining);
+
+    create_cke_packet_sequence(buffer, 1);
+
+    return WDDR_SUCCESS;
+}
+
+wddr_return_t dram_prepare_rddq_sequence(dram_dev_t *dram,
+                                         dfi_tx_packet_buffer_t *buffer,
+                                         burst_length_t burst_length,
+                                         chipselect_t cs,
+                                         uint16_t rddata_en_offset)
+{
+    command_t command = {0};
+    create_rddq_command(&command, cs);
+    return dram_prepare_read_sequence(dram, buffer, burst_length, cs, rddata_en_offset, &command);
+}
+
+wddr_return_t dram_prepare_rdfifo_sequence(dram_dev_t *dram,
+                                           dfi_tx_packet_buffer_t *buffer,
+                                           burst_length_t burst_length,
+                                           chipselect_t cs,
+                                           uint16_t rddata_en_offset)
+{
+    command_t command = {0};
+    create_rdfifo_command(&command, cs);
+    return dram_prepare_read_sequence(dram, buffer, burst_length, cs, rddata_en_offset, &command);
+}
+
+wddr_return_t dram_prepare_wrlvl_sequence(dram_dev_t *dram,
+                                          dfi_tx_packet_buffer_t *buffer)
+{
+    packet_item_t *packet;
+    uint8_t time_offset = 1;
+    packet_group_info_t wrdata_en_info;
+    uint16_t initial_dram_clk = (buffer->ts_last_packet + time_offset) << dram->cfg->ratio;
+
+    create_packet_group_info(&wrdata_en_info, dram->cfg->ratio, initial_dram_clk, 4);
+
+    do
+    {
+        packet = create_cke_packet_sequence(buffer, time_offset);
+        if (packet == NULL)
+        {
+            return WDDR_ERROR;
+        }
+
+        fill_wrdata_en_packet(packet, &wrdata_en_info, 4);
+
+        time_offset = 1;
+    } while (wrdata_en_info.phase_remaining);
+
+    create_cke_packet_sequence(buffer, 1);
+
+    return WDDR_SUCCESS;
+}
+
+void dram_prepare_mrw_update(dram_dev_t *dram,
+                             dfi_tx_packet_buffer_t *packet_buffer,
+                             dram_freq_cfg_t *dram_cfg,
+                             dram_freq_cal_t *dram_cal)
+{
+    create_cke_packet_sequence(packet_buffer, 1);
+
+    for (uint8_t rank = CS_0; rank < WDDR_PHY_RANK; rank++)
+    {
+        dram_create_mrw_packet_sequence(packet_buffer, dram->cfg->ratio, rank, 0x01, dram_cfg->mr1, 10);
+        create_cke_packet_sequence(packet_buffer, 1);
+        dram_create_mrw_packet_sequence(packet_buffer, dram->cfg->ratio, rank, 0x02, dram_cfg->mr2, 10);
+        create_cke_packet_sequence(packet_buffer, 1);
+        dram_create_mrw_packet_sequence(packet_buffer, dram->cfg->ratio, rank, 0x0B, dram_cfg->mr11, 10);
+        create_cke_packet_sequence(packet_buffer, 1);
+        dram_create_mrw_packet_sequence(packet_buffer, dram->cfg->ratio, rank, 0x0C, dram_cal->mr12, 10);
+        create_cke_packet_sequence(packet_buffer, 1);
+        dram_create_mrw_packet_sequence(packet_buffer, dram->cfg->ratio, rank, 0x0E, dram_cal->mr14, 10);
+        create_cke_packet_sequence(packet_buffer, 1);
+    }
+}
+
+static void dram_write_mode_register(dram_dev_t *dram,
+                                     dfi_buffer_dev_t *dfi_buffer,
+                                     uint8_t mr,
+                                     uint8_t op)
 {
     dfi_tx_packet_buffer_t packet_buffer;
 
     dfi_tx_packet_buffer_init(&packet_buffer);
-    create_mrw_packet_sequence(&packet_buffer, cfg->ratio, CS_0, mr, op, 1);
+    dram_create_mrw_packet_sequence(&packet_buffer, dram->cfg->ratio, CS_0, mr, op, 1);
     create_cke_packet_sequence(&packet_buffer, 1);
     dfi_buffer_fill_and_send_packets(dfi_buffer, &packet_buffer.list);
     dfi_tx_packet_buffer_free(&packet_buffer);
+}
+
+static wddr_return_t dram_create_mrw_packet_sequence(dfi_tx_packet_buffer_t *buffer,
+                                                wddr_freq_ratio_t ratio,
+                                                chipselect_t cs,
+                                                uint8_t mode_register,
+                                                uint8_t op,
+                                                uint16_t time_offset)
+{
+    command_t command = {0};
+    create_write_mode_register_command(&command, cs, mode_register, op);
+    return dram_create_address_packet_sequence(buffer, ratio, &command, time_offset);
+}
+
+static wddr_return_t dram_create_address_packet_sequence(dfi_tx_packet_buffer_t *buffer,
+                                                    wddr_freq_ratio_t ratio,
+                                                    command_t *command,
+                                                    uint16_t time_offset)
+{
+    uint8_t phase_offset = 0;
+    uint8_t num_packets = (MAX_COMMAND_FRAMES >> ratio);
+    // Five packets required for this command
+    packet_item_t *packet;
+
+    for (uint8_t i = 0; i < num_packets; i++)
+    {
+        packet = create_cke_packet_sequence(buffer, time_offset);
+        if (packet == NULL)
+        {
+            return WDDR_ERROR;
+        }
+
+        // Command
+        packet->packet.packet.cs_p0 = command->address[phase_offset].cs;
+        packet->packet.packet.cs_p1 = command->address[phase_offset].cs;
+        packet->packet.packet.address_p0 = command->address[phase_offset].ca_pins;
+        phase_offset++;
+
+        if (ratio == WDDR_FREQ_RATIO_1TO2)
+        {
+            packet->packet.packet.cs_p2 = command->address[phase_offset].cs;
+            packet->packet.packet.cs_p3 = command->address[phase_offset].cs;
+            packet->packet.packet.address_p2 = command->address[phase_offset].ca_pins;
+            phase_offset++;
+        }
+
+        time_offset = 1;
+    }
+
+    return WDDR_SUCCESS;
 }

--- a/dev/wddr/CMakeLists.txt
+++ b/dev/wddr/CMakeLists.txt
@@ -22,12 +22,18 @@ target_compile_definitions(
     -DCONFIG_CALIBRATE_PLL=${CONFIG_CALIBRATE_PLL}
     -DCONFIG_CALIBRATE_ZQCAL=${CONFIG_CALIBRATE_ZQCAL}
     -DCONFIG_CALIBRATE_SA=${CONFIG_CALIBRATE_SA}
+    -DCONFIG_DRAM_TRAIN=${CONFIG_DRAM_TRAIN}
 )
 
 target_include_directories(
     ${LIB_NAME}
     PUBLIC
     ${INCLUDE}
+)
+
+add_library(
+    wddr_ext
+    INTERFACE
 )
 
 target_link_libraries(
@@ -41,4 +47,5 @@ target_link_libraries(
     dfi
     pll
     dram
+    wddr_ext
 )

--- a/drivers/dfi/buffer_driver.c
+++ b/drivers/dfi/buffer_driver.c
@@ -101,6 +101,13 @@ void dfi_buffer_send_packets_non_blocking_reg_if(dfi_buffer_dev_t *dfi_buffer)
         reg_val = reg_read(dfi_buffer->base + DDR_DFICH_TOP_STA__ADR);
     } while (GET_REG_FIELD(reg_val, DDR_DFICH_TOP_STA_IG_STATE) != DFI_FIFO_STATE_EMPTY);
 
+    // Need to clear interrupt to ensure it doesn't fire early when using blocking method
+    /** NOTE: Only CH0 is enabled */
+    reg_val = FAST_IRQ_STICKY_MASK(DDR_IRQ_CH0_IBUF_EMPTY) |
+              FAST_IRQ_STICKY_MASK(DDR_IRQ_CH0_IBUF_FULL);
+    reg_write(WDDR_MEMORY_MAP_MCU + WAV_MCU_IRQ_FAST_CLR_CFG__ADR, reg_val);
+    reg_write(WDDR_MEMORY_MAP_MCU + WAV_MCU_IRQ_FAST_CLR_CFG__ADR, 0x0);
+
     // Disable Timestamp comparison logic
     reg_val = reg_read(dfi_buffer->base + DDR_DFICH_TOP_1_CFG__ADR);
     reg_val = UPDATE_REG_FIELD(reg_val, DDR_DFICH_TOP_1_CFG_TS_ENABLE, 0x0);

--- a/include/dev/dfi/command.h
+++ b/include/dev/dfi/command.h
@@ -80,8 +80,8 @@ typedef enum chipselect_t
  */
 typedef enum burst_length_t
 {
-    BL_16,
-    BL_32
+    BL_16 = 16,
+    BL_32 = 32
 } burst_length_t;
 
 /**

--- a/include/dev/dfi/packet.h
+++ b/include/dev/dfi/packet.h
@@ -10,6 +10,7 @@
 #include <stddef.h>
 #include <compiler.h>
 #include <dfi/command.h>
+#include <dram/table.h>
 #include <kernel/list.h>
 
 #define PACKET_BUFFER_DEPTH         (32)
@@ -30,6 +31,23 @@
 #define DFI_PACK_PARITY_WIDTH       (1)
 #define DFI_PACK_VALID_WIDTH        (1)
 #define DFI_PACK_TIME_WIDTH         (16)
+
+/**
+ * @brief   Packet Group Info Structure
+ *
+ * @details Structure containing relevant information needed to fill
+ *          appropriate phases within a packet.
+ *
+ * dfi_ts_start     Timestamp offset start of packet in DFI cycles.
+ * cycle_offset     DRAM cycle offset used to skip phases in a packet.
+ * phase_remaining  Number of phases remaining to be filled.
+ */
+typedef struct packet_group_info_t
+{
+    uint16_t dfi_ts_start;
+    uint16_t cycle_offset;
+    uint16_t phase_remaining;
+} packet_group_info_t;
 
 /**
  * @brief   Packet Data Mask Enumerations
@@ -533,8 +551,8 @@ void dfi_rx_packet_buffer_data_compare(dfi_rx_packet_buffer_t *buffer,
  * @retval      WDDR_SUCCESS if added.
  * @retval      WDDR_ERROR otherwise.
  */
-wddr_return_t create_ck_packet_sequence(dfi_tx_packet_buffer_t *buffer,
-                                        uint16_t time_offset);
+packet_item_t * create_ck_packet_sequence(dfi_tx_packet_buffer_t *buffer,
+                                          uint16_t time_offset);
 
 /**
  * @brief   Create CKE Packet Sequence
@@ -550,31 +568,101 @@ wddr_return_t create_ck_packet_sequence(dfi_tx_packet_buffer_t *buffer,
  * @retval      WDDR_SUCCESS if added.
  * @retval      WDDR_ERROR otherwise.
  */
-wddr_return_t create_cke_packet_sequence(dfi_tx_packet_buffer_t *buffer,
-                                         uint16_t time_offset);
+packet_item_t * create_cke_packet_sequence(dfi_tx_packet_buffer_t *buffer,
+                                           uint16_t time_offset);
 
 /**
- * @brief   Create MRW Packet Sequence
+ * @brief   Create Packet Group Info
  *
- * @details Creates a set of packets in order to send the specified MRW to
- *          the DRAM.
+ * @details Creates group info required for filling packet with the appropriate
+ *          phases and offsets being accounted for.
  *
- * @param[in]   buffer          pointer to packet buffer to save packet to.
+ * @param[in]   group_info      pointer to group info structure to populate.
  * @param[in]   ratio           ratio of DFI CK to DRAM CK.
- * @param[in]   cs              chipselect value.
- * @param[in]   mode_register   which mode reigster number.
- * @param[in]   op              mode register op data.
- * @param[in]   time_offset     time offset from previous packet that the packet
- *                              should be sent.
+ * @param[in]   dram_clk_cycles group offset specified in DRAM cycles.
+ * @param[in]   phase_length    duration of group specified in phases.
  *
- * @return      returns whether packet added to the packet buffer.
- * @retval      WDDR_SUCCESS if added.
- * @retval      WDDR_ERROR otherwise.
+ * @return      void.
  */
-wddr_return_t create_mrw_packet_sequence(dfi_tx_packet_buffer_t *buffer,
-                                        wddr_freq_ratio_t ratio,
-                                        chipselect_t cs,
-                                        uint8_t mode_register,
-                                        uint8_t op,
-                                        uint16_t time_offset);
+void create_packet_group_info(packet_group_info_t *group_info,
+                              wddr_freq_ratio_t ratio,
+                              uint16_t dram_clk_cycles,
+                              uint16_t phase_length);
+
+/**
+ * @brief   Fill Address Packet
+ *
+ * @details Fills correct command phases for the specified packet group by
+ *          populating cs and address data in packet.
+ *
+ * @param[in]   packet              pointer to packet to fill.
+ * @param[in]   group_info          pointer to packet group info structure.
+ * @param[in]   cycles_per_packet   number of DRAM cycles per packet
+ * @param[in]   command             pointer to command structure to send.
+ * @param[in]   phase_length        expected total phases to be populated.
+ *
+ * @return      void.
+ */
+void fill_address_packet(packet_item_t *packet,
+                         packet_group_info_t *group_info,
+                         uint8_t cycles_per_packet,
+                         command_t *command,
+                         uint16_t phase_length);
+
+/**
+ * @brief   Fill Read Data Packet
+ *
+ * @details Fills correct read phases for the specified packet group by
+ *          populating rddata_cs in packet.
+ *
+ * @param[in]   packet              pointer to packet to fill.
+ * @param[in]   group_info          pointer to packet group info structure.
+ * @param[in]   cs                  chipselect value.
+ * @param[in]   cycles_per_packet   number of DRAM cycles per packet
+ *
+ * @return      void.
+ */
+void fill_rddata_packet(packet_item_t *packet,
+                        packet_group_info_t *group_info,
+                        chipselect_t cs,
+                        uint8_t cycles_per_packet);
+
+/**
+ * @brief   Fill Write Data Enable Packet
+ *
+ * @details Fills correct write phases for the specified packet group by
+ *          populating wrdata_en in packet.
+ *
+ * @param[in]   packet              pointer to packet to fill.
+ * @param[in]   group_info          pointer to packet group info structure.
+ * @param[in]   cycles_per_packet   number of DRAM cycles per packet
+ *
+ * @return      void.
+ */
+void fill_wrdata_en_packet(packet_item_t *packet,
+                           packet_group_info_t *group_info,
+                           uint8_t cycles_per_packet);
+
+/**
+ * @brief   Fill Write Data Packet
+ *
+ * @details Fills correct write phases for the specified packet group by
+ *          populating wrdata, wrdata_mask, and wrdata_cs in packet.
+ *
+ * @param[in]   packet              pointer to packet to fill.
+ * @param[in]   group_info          pointer to packet group info structure.
+ * @param[in]   cs                  chipselect value.
+ * @param[in]   data                pointer to command data structure to send.
+ * @param[in]   cycles_per_packet   number of DRAM cycles per packet
+ * @param[in]   phase_length        expected total phases to be populated.
+ *
+ * @return      void.
+ */
+void fill_wrdata_packet(packet_item_t *packet,
+                        packet_group_info_t *group_info,
+                        chipselect_t cs,
+                        command_data_t *data,
+                        uint8_t cycles_per_packet,
+                        uint16_t phase_length);
+
 #endif /* _DFI_PACKET_H_ */

--- a/include/dev/dram/device.h
+++ b/include/dev/dram/device.h
@@ -19,13 +19,15 @@
  *          the DFI interface is controlled via Memory Controller. Typically,
  *          this device is only used during DRAM training.
  *
- * mr2      Stores current value of MR2 in DRAM.
  * mr13     Stores current value of MR13 in DRAM.
+ * cal      Pointer to current DRAM freq cal structure.
+ * cfg      Pointer to current DRAM freq cfg structure.
  */
 typedef struct dram_dev_t
 {
-    uint8_t mr2;
-    uint8_t mr13;
+    uint8_t         mr13;
+    dram_freq_cal_t *cal;
+    dram_freq_cfg_t *cfg;
 } dram_dev_t;
 
 /**
@@ -33,11 +35,30 @@ typedef struct dram_dev_t
  *
  * @details Initializes the DRAM device at the device level.
  *
- * @param[in]   dram    pointer to DRAM device.
+ * @param[in]   dram        pointer to DRAM device.
+ * @param[in]   dram_cfg    pointer to DRAM Frequency Configuration data.
+ * @param[in]   dram_cal    pointer to DRAM Frequency Calibration data.
  *
  * @return      void
  */
-void dram_init(dram_dev_t *dram);
+void dram_init(dram_dev_t *dram,
+               dram_freq_cfg_t *dram_cfg,
+               dram_freq_cal_t *dram_cal);
+
+/**
+ * @brief   DRAM Frequency Set
+ *
+ * @details Sets frequency specific config and calibration in DRAM device
+ *
+ * @param[in]   dram        pointer to DRAM device.
+ * @param[in]   dram_cfg    pointer to DRAM Frequency Configuration data.
+ * @param[in]   dram_cal    pointer to DRAM Frequency Calibration data.
+ *
+ * @return      void
+ */
+void dram_frequency_set(dram_dev_t *dram,
+                        dram_freq_cfg_t *dram_cfg,
+                        dram_freq_cal_t *dram_cal);
 
 /**
  * @brief   DRAM Power Down
@@ -92,13 +113,11 @@ void dram_frequency_init(dram_dev_t *dram,
  *
  * @param[in]   dram            pointer to DRAM device.
  * @param[in]   dfi_buffer      pointer to DFI Buffer device.
- * @param[in]   cfg             pointer to DRAM Frequency Configuration data.
  *
  * @return      void
  */
 void dram_cbt_enter(dram_dev_t *dram,
-                    dfi_buffer_dev_t *dfi_buffer,
-                    dram_freq_cfg_t *cfg);
+                    dfi_buffer_dev_t *dfi_buffer);
 
 /**
  * @brief   DRAM Command Bus Training (CBT) Exit
@@ -110,13 +129,86 @@ void dram_cbt_enter(dram_dev_t *dram,
  *
  * @param[in]   dram            pointer to DRAM device.
  * @param[in]   dfi_buffer      pointer to DFI Buffer device.
- * @param[in]   cfg             pointer to DRAM Frequency Configuration data.
  *
  * @return      void
  */
 void dram_cbt_exit(dram_dev_t *dram,
-                   dfi_buffer_dev_t *dfi_buffer,
-                   dram_freq_cfg_t *cfg);
+                   dfi_buffer_dev_t *dfi_buffer);
+
+/**
+ * @brief   DRAM FSP WR Set
+ *
+ * @details Sets desired FSP-WR value in DRAM.
+ *
+ * @param[in]   dram            pointer to DRAM device.
+ * @param[in]   dfi_buffer      pointer to DFI Buffer device.
+ * @param[in]   fsp             desired FSP to set WR to.
+ *
+ * @return      void
+ */
+void dram_set_fsp_wr(dram_dev_t *dram,
+                     dfi_buffer_dev_t *dfi_buffer,
+                     uint8_t fsp);
+
+/**
+ * @brief   DRAM FSP OP Set
+ *
+ * @details Sets desired FSP-OP value in DRAM.
+ *
+ * @note    This will also set FSP-WR to same FSP as FSP-OP.
+ *
+ * @param[in]   dram            pointer to DRAM device.
+ * @param[in]   dfi_buffer      pointer to DFI Buffer device.
+ * @param[in]   fsp             desired FSP to set OP to.
+ *
+ * @return      void
+ */
+void dram_set_fsp_op(dram_dev_t *dram,
+                     dfi_buffer_dev_t *dfi_buffer,
+                     uint8_t fsp);
+
+/**
+ * @brief   DRAM DQ VREF Set
+ *
+ * @details Sets desired DQ VREF value in DRAM.
+ *
+ * @param[in]   dram            pointer to DRAM device.
+ * @param[in]   dfi_buffer      pointer to DFI Buffer device.
+ * @param[in]   vref_setting    desired DQ VREF value to set.
+ *
+ * @return      void
+ */
+void dram_set_dq_vref(dram_dev_t *dram,
+                      dfi_buffer_dev_t *dfi_buffer,
+                      uint8_t vref_setting);
+
+/**
+ * @brief   DRAM Write Level Training Enable
+ *
+ * @details Enables Write Level Training in DRAM using DFI Buffer.
+ *
+ *
+ * @param[in]   dram            pointer to DRAM device.
+ * @param[in]   dfi_buffer      pointer to DFI Buffer device.
+ *
+ * @return      void
+ */
+void dram_wrlvl_enable(dram_dev_t *dram,
+                       dfi_buffer_dev_t *dfi_buffer);
+
+/**
+ * @brief   DRAM Write Level Training Disable
+ *
+ * @details Disables Write Level Training in DRAM using DFI Buffer.
+ *
+ *
+ * @param[in]   dram            pointer to DRAM device.
+ * @param[in]   dfi_buffer      pointer to DFI Buffer device.
+ *
+ * @return      void
+ */
+void dram_wrlvl_disable(dram_dev_t *dram,
+                        dfi_buffer_dev_t *dfi_buffer);
 
 /**
  * @brief   DRAM Vref Current Generator(VRCG) Enable
@@ -126,13 +218,11 @@ void dram_cbt_exit(dram_dev_t *dram,
  *
  * @param[in]   dram            pointer to DRAM device.
  * @param[in]   dfi_buffer      pointer to DFI Buffer device.
- * @param[in]   cfg             pointer to DRAM Frequency Configuration data.
  *
  * @return      void
  */
 void dram_vrcg_enable(dram_dev_t *dram,
-                      dfi_buffer_dev_t *dfi_buffer,
-                      dram_freq_cfg_t *cfg);
+                      dfi_buffer_dev_t *dfi_buffer);
 
 /**
  * @brief   DRAM Vref Current Generator(VRCG) Disable
@@ -142,13 +232,11 @@ void dram_vrcg_enable(dram_dev_t *dram,
  *
  * @param[in]   dram            pointer to DRAM device.
  * @param[in]   dfi_buffer      pointer to DFI Buffer device.
- * @param[in]   cfg             pointer to DRAM Frequency Configuration data.
  *
  * @return      void
  */
 void dram_vrcg_disable(dram_dev_t *dram,
-                       dfi_buffer_dev_t *dfi_buffer,
-                       dram_freq_cfg_t *cfg);
+                       dfi_buffer_dev_t *dfi_buffer);
 
 /**
  * @brief   DRAM Write Mode Register 13
@@ -157,15 +245,28 @@ void dram_vrcg_disable(dram_dev_t *dram,
  *
  * @param[in]   dram            pointer to DRAM device.
  * @param[in]   dfi_buffer      pointer to DFI Buffer device.
- * @param[in]   cfg             pointer to DRAM Frequency Configuration data.
  * @param[in]   mr13            the value of MR13 to set.
  *
  * @return      void
  */
 void dram_write_mode_register_13(dram_dev_t *dram,
                                  dfi_buffer_dev_t *dfi_buffer,
-                                 dram_freq_cfg_t *cfg,
                                  uint8_t mr13);
+
+/**
+ * @brief   DRAM Write Mode Register 14
+ *
+ * @details Sets the value of Mode Register 14 in DRAM using DFI Buffer.
+ *
+ * @param[in]   dram            pointer to DRAM device.
+ * @param[in]   dfi_buffer      pointer to DFI Buffer device.
+ * @param[in]   mr14            the value of MR13 to set.
+ *
+ * @return      void
+ */
+void dram_write_mode_register_14(dram_dev_t *dram,
+                                 dfi_buffer_dev_t *dfi_buffer,
+                                 uint8_t mr14);
 
 /**
  * @brief   DRAM Write Mode Register 2
@@ -174,14 +275,12 @@ void dram_write_mode_register_13(dram_dev_t *dram,
  *
  * @param[in]   dram            pointer to DRAM device.
  * @param[in]   dfi_buffer      pointer to DFI Buffer device.
- * @param[in]   cfg             pointer to DRAM Frequency Configuration data.
  * @param[in]   mr13            the value of MR2 to set.
  *
  * @return      void
  */
 void dram_write_mode_register_2(dram_dev_t *dram,
                                 dfi_buffer_dev_t *dfi_buffer,
-                                dram_freq_cfg_t *cfg,
                                 uint8_t mr2);
 
 /**
@@ -225,5 +324,158 @@ void dram_get_write_enable_offset_timing(dram_freq_cfg_t *dram_cfg,
  */
 void dram_get_write_data_offset_timing(dram_freq_cfg_t *dram_cfg,
                                        uint8_t *offset);
+
+/**
+ * @brief   DRAM Prepare Command Bus Training Packet Sequence
+ *
+ * @details Creates a set of packets in order to send the necessary DRAM signals
+ *          specifying VREF setting to use and command address and clock signals
+ *          during command bus training.
+ *
+ * @note    This will always create the packets at time offset of 1 from
+ *          timestamp of last packet in the buffer.
+ *
+ * @note    This command is expected to be used with an empty buffer.
+ *
+ * @param[in]   dram            pointer to DRAM device.
+ * @param[in]   buffer          pointer to packet buffer to save packet to.
+ * @param[in]   cs              chipselect value.
+ * @param[in]   vref_setting    VREF value to send via DQ bits during CBT.
+ * @param[in]   command_address command address value used to train.
+ *
+ * @return      returns whether packet added to the packet buffer.
+ * @retval      WDDR_SUCCESS if added.
+ * @retval      WDDR_ERROR otherwise.
+ */
+wddr_return_t dram_prepare_cbt_sequence(dram_dev_t *dram,
+                                        dfi_tx_packet_buffer_t *buffer,
+                                        chipselect_t cs,
+                                        uint8_t vref_setting,
+                                        uint8_t command_address);
+
+/**
+ * @brief   DRAM Prepare Write FIFO Packet Sequence
+ *
+ * @details Creates a set of packets in order to write data into the DRAM
+ *          FIFO for reading without disrupting array contents.
+ *
+ * @note    This will always create the packets at time offset of 1 from
+ *          timestamp of last packet in the buffer.
+ *
+ * @note    This command is expected to be used with an empty buffer.
+ *
+ * @param[in]   dram                pointer to DRAM device.
+ * @param[in]   buffer              pointer to packet buffer to save packet to.
+ * @param[in]   burst_length        data burst length of the DRAM.
+ * @param[in]   cs                  chipselect value.
+ * @param[in]   wrdata_en_offset    write enable delay value to be used.
+ * @param[in]   data                pointer to command data structure to send.
+ *
+ * @return      returns whether packet added to the packet buffer.
+ * @retval      WDDR_SUCCESS if added.
+ * @retval      WDDR_ERROR otherwise.
+ */
+wddr_return_t dram_prepare_wrfifo_sequence(dram_dev_t *dram,
+                                           dfi_tx_packet_buffer_t *buffer,
+                                           burst_length_t burst_length,
+                                           chipselect_t cs,
+                                           uint16_t wrdata_en_offset,
+                                           command_data_t *data);
+
+/**
+ * @brief   DRAM Prepare Read DQ Calibration Training Packet Sequence
+ *
+ * @details Creates a set of packets in order to send the Read DQ Calibration
+ *          Training sequence to the DRAM.
+ *
+ * @note    This will always create the packets at time offset of 1 from
+ *          timestamp of last packet in the buffer.
+ *
+ * @note    This command is expected to be used with an empty buffer.
+ *
+ * @param[in]   dram                pointer to DRAM device.
+ * @param[in]   buffer              pointer to packet buffer to save packet to.
+ * @param[in]   burst_length        data burst length of the DRAM.
+ * @param[in]   cs                  chipselect value.
+ * @param[in]   rddata_en_offset    read enable delay value to be used.
+ *
+ * @return      returns whether packet added to the packet buffer.
+ * @retval      WDDR_SUCCESS if added.
+ * @retval      WDDR_ERROR otherwise.
+ */
+wddr_return_t dram_prepare_rddq_sequence(dram_dev_t *dram,
+                                         dfi_tx_packet_buffer_t *buffer,
+                                         burst_length_t burst_length,
+                                         chipselect_t cs,
+                                         uint16_t rddata_en_offset);
+
+/**
+ * @brief   DRAM Prepare Read FIFO Packet Sequence
+ *
+ * @details Creates a set of packets in order to read data from the DRAM
+ *          FIFO.
+ *
+ * @note    This will always create the packets at time offset of WRITE_LATENCY
+ *          + BL + TWTR + 1 from timestamp of last packet in the buffer.
+ *
+ * @param[in]   dram                pointer to DRAM device.
+ * @param[in]   buffer              pointer to packet buffer to save packet to.
+ * @param[in]   burst_length        data burst length of the DRAM.
+ * @param[in]   cs                  chipselect value.
+ * @param[in]   rddata_en_offset    read enable delay value to be used.
+ *
+ * @return      returns whether packet added to the packet buffer.
+ * @retval      WDDR_SUCCESS if added.
+ * @retval      WDDR_ERROR otherwise.
+ */
+wddr_return_t dram_prepare_rdfifo_sequence(dram_dev_t *dram,
+                                           dfi_tx_packet_buffer_t *buffer,
+                                           burst_length_t burst_length,
+                                           chipselect_t cs,
+                                           uint16_t rddata_en_offset);
+
+/**
+ * @brief   DRAM Prepare Write Level Training Packet Sequence
+ *
+ * @details Creates a set of packets in order to send the specified Write
+ *          Level Training sequence to the DRAM.
+ *
+ * @note    This will always create the packets at time offset of 1 from
+ *          timestamp of last packet in the buffer.
+ *
+ * @note    This command is expected to be used with an empty buffer.
+ *
+ * @param[in]   dram            pointer to DRAM device.
+ * @param[in]   buffer          pointer to packet buffer to save packet to.
+ *
+ * @return      returns whether packet added to the packet buffer.
+ * @retval      WDDR_SUCCESS if added.
+ * @retval      WDDR_ERROR otherwise.
+ */
+wddr_return_t dram_prepare_wrlvl_sequence(dram_dev_t *dram,
+                                          dfi_tx_packet_buffer_t *buffer);
+
+/**
+ * @brief   DRAM Prepare MRW Update Packet Sequence
+ *
+ * @details Creates a set of packets in order to send the specified MRW
+ *          update sequence to the DRAM.
+ *
+ * @note    This will always create the packets at time offset of 1 from
+ *          timestamp of last packet in the buffer.
+ *
+ * @note    This command is expected to be used with an empty buffer.
+ *
+ * @param[in]   dram        pointer to DRAM device.
+ * @param[in]   buffer      pointer to packet buffer to save packet to.
+ * @param[in]   dram_cfg    pointer to DRAM Frequency Configuration data.
+ * @param[in]   dram_cal    pointer to DRAM Frequency Calibration data.
+ *
+ * @return      void.
+ */
+void dram_prepare_mrw_update(dram_dev_t *dram,
+                             dfi_tx_packet_buffer_t *packet_buffer,
+                             dram_freq_cfg_t *dram_cfg,
+                             dram_freq_cal_t *dram_cal);
 
 #endif /* _DRAM_DEV_H_ */

--- a/include/dev/wddr/phy_config.h
+++ b/include/dev/wddr/phy_config.h
@@ -19,5 +19,6 @@
 #define WDDR_PHY_CK_TXRX_SLICE_NUM          (1)
 #define WDDR_PHY_DQ_BYTE_NUM                (WDDR_DQ_BYTE_TOTAL)
 #define WDDR_PHY_CHANNEL_NUM                (WDDR_CHANNEL_TOTAL)
+#define WDDR_PHY_MAX_FREQ_RATIO             (WDDR_PHY_FREQ_RATIO_1TO2)
 
 #endif /* _WDDR_PHY_CONFIG_H_ */

--- a/include/dev/wddr/phy_defs.h
+++ b/include/dev/wddr/phy_defs.h
@@ -6,6 +6,10 @@
 #ifndef _WDDR_PHY_DEFS_H_
 #define _WDDR_PHY_DEFS_H_
 
+#define WDDR_PHY_FREQ_RATIO_1TO1 (0)
+#define WDDR_PHY_FREQ_RATIO_1TO2 (1)
+#define WDDR_PHY_FREQ_RATIO_1TO4 (2)
+
 /**
  * @brief   WDDR PHY Channel Index Enuemrations
  *
@@ -169,15 +173,15 @@ typedef enum wddr_msr_t
  *
  * @details DFI frequency to DRAM frequency ratio.
  *
- * 1TO1     DRAM tCK = 1 * DFI tCK
- * 1TO2     DRAM tCK = 2 * DFI tCK
- * 1TO4     DRAM tCK = 4 * DFI tCK
+ * 1TO1     1 DRAM tCK = (1 << 0) DFI tCK
+ * 1TO2     1 DRAM tCK = (1 << 1) DFI tCK
+ * 1TO4     1 DRAM tCK = (1 << 2) DFI tCK
  */
 typedef enum wddr_freq_ratio_t
 {
-    WDDR_FREQ_RATIO_1TO1 = 0,
-    WDDR_FREQ_RATIO_1TO2 = 1,
-    WDDR_FREQ_RATIO_1TO4 = 2,
+    WDDR_FREQ_RATIO_1TO1 = WDDR_PHY_FREQ_RATIO_1TO1,
+    WDDR_FREQ_RATIO_1TO2 = WDDR_PHY_FREQ_RATIO_1TO2,
+    WDDR_FREQ_RATIO_1TO4 = WDDR_PHY_FREQ_RATIO_1TO4,
 } wddr_freq_ratio_t;
 
 #endif /* _WDDR_PHY_DEFS_H_ */


### PR DESCRIPTION
Fixes
  - Fixed DFI Buffer clearing IRQ when polling status during send.

Features
  - Added DFI Buffer packet generation sequences used during training.
  - Updated DRAM device to store cal and cfg frequency information after switch.
  - Added DRAM FSP control functions.
  - Included weak wddr_train function, to be implemented externally.