### PR TITLE
Loopback API

### DIFF
--- a/dev/dfi/buffer_device.c
+++ b/dev/dfi/buffer_device.c
@@ -74,7 +74,15 @@ static wddr_return_t dfi_buffer_write_packets(dfi_buffer_dev_t *dfi_buffer,
 {
     wddr_return_t ret = WDDR_SUCCESS;
     packet_item_t *packet_item;
-    ListItem_t *next = listGET_HEAD_ENTRY(packet_list);
+    ListItem_t *next;
+
+    // Should have at least one packet
+    if (listLIST_IS_EMPTY(packet_list))
+    {
+        return WDDR_ERROR;
+    }
+
+    next = listGET_HEAD_ENTRY(packet_list);
 
     /**
      * Send all packets except the last packet.

--- a/dev/driver/device.c
+++ b/dev/driver/device.c
@@ -60,9 +60,42 @@ void driver_override(driver_dev_t *driver,
                      driver_cfg_t *cfg,
                      wddr_slice_type_t slice_type,
                      uint8_t bit_index,
-                     bool override)
+                     bool output_enable)
 {
     driver_set_impedance_reg_if(driver, slice_type, bit_index, cfg->tx_impd, cfg->rx_impd);
     driver_set_override_reg_if(driver, slice_type, bit_index, cfg->override.sel, cfg->override.val_t, cfg->override.val_c);
-    driver_set_oe_reg_if(driver, slice_type, bit_index, override);
+    driver_set_oe_reg_if(driver, slice_type, bit_index, output_enable);
+}
+
+void driver_override_all_bits(driver_dev_t *driver,
+                              wddr_slice_type_t slice_type,
+                              driver_cfg_t *cfg,
+                              bool output_enable)
+{
+    uint8_t num_bits, bit_index;
+
+    // Loop parameter
+    switch(slice_type)
+    {
+        case WDDR_SLICE_TYPE_DQ:
+            num_bits = WDDR_PHY_DQ_SLICE_NUM;
+            break;
+        case WDDR_SLICE_TYPE_DQS:
+            num_bits = WDDR_PHY_DQS_TXRX_SLICE_NUM;
+            break;
+        case WDDR_SLICE_TYPE_CA:
+            num_bits = WDDR_PHY_CA_SLICE_NUM;
+            break;
+        case WDDR_SLICE_TYPE_CK:
+            num_bits = WDDR_PHY_CK_TXRX_SLICE_NUM;
+            break;
+        default:
+            return;
+    }
+
+    // Set all bits
+    for (bit_index = 0; bit_index < num_bits; bit_index++)
+    {
+        driver_override(driver, cfg, slice_type, bit_index, output_enable);
+    }
 }

--- a/drivers/dfi/driver.c
+++ b/drivers/dfi/driver.c
@@ -128,25 +128,37 @@ void dfi_ovr_traffic_cfg_reg_if(dfi_dev_t *dfi, dfi_ovr_traffic_cfg_t *cfg)
     reg_write(dfi->base + DDR_DFICH_CTRL1_M0_CFG__ADR + dfi->msr * DFI_MODE__OFFSET, cfg->val);
 }
 
-void dfi_set_init_complete_ovr_reg_if(bool enable)
+void dfi_set_init_complete_ovr_reg_if(bool override, uint8_t val)
 {
     uint32_t reg_val;
 
     reg_val = reg_read(WDDR_MEMORY_MAP_DFI + DDR_DFI_STATUS_IF_CFG__ADR);
-    reg_val = UPDATE_REG_FIELD(reg_val, DDR_DFI_STATUS_IF_CFG_SW_ACK_OVR, enable);
+    reg_val = UPDATE_REG_FIELD(reg_val, DDR_DFI_STATUS_IF_CFG_SW_ACK_VAL, val);
+    reg_write(WDDR_MEMORY_MAP_DFI + DDR_DFI_STATUS_IF_CFG__ADR, reg_val);
+    reg_val = UPDATE_REG_FIELD(reg_val, DDR_DFI_STATUS_IF_CFG_SW_ACK_OVR, override);
     reg_write(WDDR_MEMORY_MAP_DFI + DDR_DFI_STATUS_IF_CFG__ADR, reg_val);
 }
 
-void dfi_set_init_start_ovr_reg_if(bool enable)
+void dfi_set_init_start_ovr_reg_if(bool override, uint8_t val)
 {
     uint32_t reg_val;
 
     reg_val = reg_read(WDDR_MEMORY_MAP_DFI + DDR_DFI_STATUS_IF_CFG__ADR);
-    reg_val = UPDATE_REG_FIELD(reg_val, DDR_DFI_STATUS_IF_CFG_SW_REQ_OVR, enable);
+    reg_val = UPDATE_REG_FIELD(reg_val, DDR_DFI_STATUS_IF_CFG_SW_REQ_VAL, val);
+    reg_write(WDDR_MEMORY_MAP_DFI + DDR_DFI_STATUS_IF_CFG__ADR, reg_val);
+    reg_val = UPDATE_REG_FIELD(reg_val, DDR_DFI_STATUS_IF_CFG_SW_REQ_OVR, override);
     reg_write(WDDR_MEMORY_MAP_DFI + DDR_DFI_STATUS_IF_CFG__ADR, reg_val);
 }
 
 void dfi_get_init_start_status_reg_if(uint32_t *init_start)
 {
     *init_start = GET_REG_FIELD(reg_read(WDDR_MEMORY_MAP_DFI + DDR_DFI_STATUS_IF_STA__ADR), DDR_DFI_STATUS_IF_STA_REQ);
+}
+
+void dfi_ca_read_loopback_enable_reg_if(bool enable)
+{
+    uint32_t reg_val;
+    reg_val = reg_read(WDDR_MEMORY_MAP_DFI_CH0 +  DDR_DFICH_TOP_1_CFG__ADR);
+    reg_val = UPDATE_REG_FIELD(reg_val, DDR_DFICH_TOP_1_CFG_CA_RDDATA_EN, enable);
+    reg_write(WDDR_MEMORY_MAP_DFI_CH0 +  DDR_DFICH_TOP_1_CFG__ADR, reg_val);
 }

--- a/include/dev/driver/device.h
+++ b/include/dev/driver/device.h
@@ -99,11 +99,11 @@ void driver_set_impedance_all_bits(driver_dev_t *driver,
  * @details Overrides the Driver device output for a given bit within a given
  *          slice.
  *
- * @param[in]   driver      pointer to Driver device.
- * @param[in]   cfg         pointer to Driver device configuration.
- * @param[in]   slice_type  type of slice to configure.
- * @param[in]   bit_index   which bit to configure.
- * @param[in]   override    flag to indicate if sw override is enabled.
+ * @param[in]   driver          pointer to Driver device.
+ * @param[in]   cfg             pointer to Driver device configuration.
+ * @param[in]   slice_type      type of slice to configure.
+ * @param[in]   bit_index       which bit to configure.
+ * @param[in]   output_enable   flag to indicate if output is enabled.
  *
  * @return      void
  */
@@ -111,6 +111,23 @@ void driver_override(driver_dev_t *driver,
                      driver_cfg_t *cfg,
                      wddr_slice_type_t slice_type,
                      uint8_t bit_index,
-                     bool override);
+                     bool output_enable);
+
+/**
+ * @brief   Driver Override All Bits
+ *
+ * @details Sets the Driver device settings for all bits for the given slice.
+ *
+ * @param[in]   driver          pointer to Driver device.
+ * @param[in]   slice_type      slice type of Driver device.
+ * @param[in]   cfg             pointer to Driver device configuration.
+ * @param[in]   output_enable   flag to indicate if output is enabled.
+ *
+ * @return      void
+ */
+void driver_override_all_bits(driver_dev_t *driver,
+                              wddr_slice_type_t slice_type,
+                              driver_cfg_t *cfg,
+                              bool output_enable);
 
 #endif /* _DRIVER_DEV_H_ */

--- a/include/dev/wddr/device.h
+++ b/include/dev/wddr/device.h
@@ -123,4 +123,20 @@ wddr_return_t wddr_boot(wddr_dev_t *wddr);
  */
 wddr_return_t wddr_prep_switch(wddr_dev_t *wddr, uint8_t freq_id);
 
+/**
+ * @brief   WDDR Enable Loopback
+ *
+ * @details Enables Loopback mode for WDDR device.
+ *
+ * @note    This is only used for training modes. It should never be used
+ *          otherwise.
+ *
+ * @note    Perform a frequency prep and switch to reset loopback state.
+ *
+ * @param[in]   wddr    pointer to WDDR device.
+ *
+ * @return  void.
+ */
+void wddr_enable_loopback(wddr_dev_t *wddr);
+
 #endif /* _WDDR_DEV_H_ */

--- a/include/drivers/dfi/driver.h
+++ b/include/drivers/dfi/driver.h
@@ -172,22 +172,24 @@ void dfi_ovr_traffic_cfg_reg_if(dfi_dev_t *dfi, dfi_ovr_traffic_cfg_t *cfg);
  *
  * @details Set Init Complete Override via CSR.
  *
- * @param[in]   enable  Init Complete Override CSR value.
+ * @param[in]   override    Init Complete sw override enable.
+ * @param[in]   val         Init Complete override value.
  *
  * @return      void
  */
-void dfi_set_init_complete_ovr_reg_if(bool enable);
+void dfi_set_init_complete_ovr_reg_if(bool override, uint8_t val);
 
 /**
  * @brief   DFI Set Init Start SW Override Register Interface
  *
  * @details Set Init Start Override via CSR.
  *
- * @param[in]   enable  Init Start Override CSR value.
+ * @param[in]   override    Init Start sw override enable.
+ * @param[in]   val         Init Start override value.
  *
  * @return      void
  */
-void dfi_set_init_start_ovr_reg_if(bool enable);
+void dfi_set_init_start_ovr_reg_if(bool override, uint8_t val);
 
 /**
  * @brief   DFI Get Init Start Status Register Interface
@@ -199,5 +201,17 @@ void dfi_set_init_start_ovr_reg_if(bool enable);
  * @return      void
  */
 void dfi_get_init_start_status_reg_if(uint32_t *init_start);
+
+/**
+ * @brief   DFI Command Address Read Loopback Enable Register Interface
+ *
+ * @details Enables Command Address (CA) Read Loopback path via CSR.
+ *
+ * @param[in]   enable  flag to indicate if CA Read loopback path
+ *                      should be enabled.
+ *
+ * @return  void
+ */
+void dfi_ca_read_loopback_enable_reg_if(bool enable);
 
 #endif /* _DFI_DRIVER_H_ */


### PR DESCRIPTION
Fixes:
  - Fixes #63 (Empty packet list issue)
  - Fixes issue where Frequency Switch FSM handles an
    invalid init_start interrupt

Features:
  - Driver API to override for init_start and init_complete
    now allows for override value to be set
  - Loopback API support (#64)