### PR TITLE
WDDR PHY Prep API

### DIFF
--- a/dev/fsw/device.c
+++ b/dev/fsw/device.c
@@ -85,6 +85,16 @@ void fsw_switch_to_dfi_mode(fsw_dev_t *dev)
     dev->mode = FSW_MODE_DFI;
 }
 
+wddr_msr_t fsw_get_current_msr(__UNUSED__ fsw_dev_t *dev)
+{
+    return fsw_ctrl_get_current_msr_reg_if();
+}
+
+wddr_msr_t fsw_get_next_msr(fsw_dev_t *dev)
+{
+    return !fsw_get_current_msr(dev);
+}
+
 static void handle_init_start_irq(__UNUSED__ int irq_num, __UNUSED__ void *args)
 {
     BaseType_t xHigherPriorityTaskWoken;

--- a/dev/wddr/device.c
+++ b/dev/wddr/device.c
@@ -248,23 +248,16 @@ wddr_return_t wddr_boot(wddr_dev_t *wddr)
     return WDDR_SUCCESS;
 }
 
-wddr_return_t wddr_prep_switch(wddr_dev_t *wddr, uint8_t freq_id)
+wddr_return_t wddr_prep_switch(wddr_dev_t *wddr, uint8_t freq_id, wddr_msr_t msr)
 {
-    uint32_t reg_val;
-    uint8_t next_msr;
-
     if (freq_id >= WDDR_PHY_FREQ_NUM ||
         !wddr->table->valid[freq_id])
     {
         return WDDR_ERROR;
     }
 
-    // Get next MSR
-    reg_val = reg_read(WDDR_MEMORY_MAP_FSW + DDR_FSW_CTRL_STA__ADR);
-    next_msr = !GET_REG_FIELD(reg_val, DDR_FSW_CTRL_STA_CMN_MSR);
-
     // Configure PHY
-    wddr_configure_phy(wddr, freq_id, next_msr);
+    wddr_configure_phy(wddr, freq_id, msr);
 
     // Prepare MRW sequence in DFI Buffer
     wddr_prep_freq_switch_mrw_update(wddr,

--- a/drivers/fsw/driver.c
+++ b/drivers/fsw/driver.c
@@ -52,13 +52,19 @@ void fsw_ctrl_set_prep_done_reg_if(bool done)
     reg_write(WDDR_MEMORY_MAP_FSW + DDR_FSW_CTRL_CFG__ADR, reg_val);
 }
 
-void fsw_ctrl_set_post_work_done(bool override, bool done)
+void fsw_ctrl_set_post_work_done_reg_if(bool override, bool done)
 {
     uint32_t reg_val;
     reg_val = reg_read(WDDR_MEMORY_MAP_FSW + DDR_FSW_CTRL_CFG__ADR);
     reg_val = UPDATE_REG_FIELD(reg_val, DDR_FSW_CTRL_CFG_PSTWORK_DONE, done);
     reg_val = UPDATE_REG_FIELD(reg_val, DDR_FSW_CTRL_CFG_PSTWORK_DONE_OVR, override);
     reg_write(WDDR_MEMORY_MAP_FSW + DDR_FSW_CTRL_CFG__ADR, reg_val);
+}
+
+uint8_t fsw_ctrl_get_current_msr_reg_if(void)
+{
+    // Double flip to ensure only read as one or zero
+    return !!GET_REG_FIELD(reg_read(WDDR_MEMORY_MAP_FSW + DDR_FSW_CTRL_STA__ADR), DDR_FSW_CTRL_STA_CMN_MSR);
 }
 
 void fsw_csp_set_clk_disable_ovr_val_reg_if(bool enable)

--- a/include/dev/fsw/device.h
+++ b/include/dev/fsw/device.h
@@ -6,6 +6,8 @@
 #ifndef _FSW_DEV_H_
 #define _FSW_DEV_H_
 
+#include <wddr/phy_defs.h>
+
 /**
  * @brief   Frequency Switch Modes
  *
@@ -17,7 +19,6 @@ typedef enum fsw_mode
     FSW_MODE_SW,
     FSW_MODE_DFI,
 } fsw_mode_t;
-
 
 /**
  * @brief   Frequency Switch Device Structure
@@ -54,5 +55,30 @@ void fsw_init(fsw_dev_t *dev);
  * @return  void.
  */
 void fsw_switch_to_dfi_mode(fsw_dev_t *dev);
+
+/**
+ * @brief   Frequency Switch Get Current Mode Switch Register (MSR)
+ *
+ * @details Returns the current Mode Switch Register configured in the PHY.
+ *          PHY supports two concurrent configurations. The MSR indicates which
+ *          of the configurations the PHY uses currently.
+ *
+ * @return  returns current Mode Switch Register value.
+ * @retval  possible values are WDDR_MSR_0 and WDDR_MSR_1.
+ */
+wddr_msr_t fsw_get_current_msr(fsw_dev_t *dev);
+
+/**
+ * @brief   Frequency Switch Get Next Mode Switch Register (MSR)
+ *
+ * @details Returns the next Mode Switch Register configured in the PHY.
+ *          PHY supports two concurrent configurations. The MSR indicates which
+ *          of the configurations the PHY uses currently. This function returns
+ *          the next MSR not in use.
+ *
+ * @return  returns current Mode Switch Register value.
+ * @retval  possible values are WDDR_MSR_0 and WDDR_MSR_1.
+ */
+wddr_msr_t fsw_get_next_msr(fsw_dev_t *dev);
 
 #endif /* _FSW_DEV_H_ */

--- a/include/dev/wddr/device.h
+++ b/include/dev/wddr/device.h
@@ -107,12 +107,15 @@ wddr_return_t wddr_boot(wddr_dev_t *wddr);
  *
  * @param[in]   wddr    pointer to WDDR device.
  * @param[in]   freq_id ID of frequency to prepare.
+ * @param[in]   msr     mode switch register to prepare.
  *
  * @return      returns whether prep completed successfully.
  * @retval      WDDR_SUCCESS if successful.
  * @retval      WDDR_ERROR otherwise.
  */
-wddr_return_t wddr_prep_switch(wddr_dev_t *wddr, uint8_t freq_id);
+wddr_return_t wddr_prep_switch(wddr_dev_t *wddr,
+                               uint8_t freq_id,
+                               wddr_msr_t msr);
 
 /**
  * @brief   Wavious DDR (WDDR) Software Frequency Switch

--- a/include/drivers/fsw/driver.h
+++ b/include/drivers/fsw/driver.h
@@ -75,7 +75,17 @@ void fsw_ctrl_set_prep_done_reg_if(bool done);
  *
  * @return      void.
  */
-void fsw_ctrl_set_post_work_done(bool override, bool done);
+void fsw_ctrl_set_post_work_done_reg_if(bool override, bool done);
+
+/**
+ * @brief   HW Frequency Switch Get Current MSR Register Interface
+ *
+ * @details Gets the current Mode Switch Register (MSR) in the PHY.
+ *
+ * @return  returns current Mode Switch Register value.
+ * @retval  Possible MSRs values are 0 and 1.
+ */
+uint8_t fsw_ctrl_get_current_msr_reg_if(void);
 
 /**
  * @brief   HW Frequency Switch (FSW) Clock Disable Override Register Interface


### PR DESCRIPTION
Fixes:
  - None

Features:
  - WDDR Prep API updated to take MSR as parameter
    rather than implicitly using next MSR. This
    made it easier to pair a call to this function
    with a call to software frequency switch function.