### PR TITLE
RTOS v1.3.0 Integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,10 @@ message("DRAM_TRAIN:    ${CONFIG_DRAM_TRAIN}")
 set(CONFIG_CAL_PERIODIC false CACHE BOOL "Flag to indicate if periodic calibraiton is performed.")
 message("PERIODIC CAL:  ${CONFIG_CAL_PERIODIC}")
 
+# MCU Interrupt Configuration
+set(CONFIG_WAV_MCU_IRQ_SYNC_CFG 0x00000403)
+set(CONFIG_WAV_MCU_IRQ_EDGE_CFG 0x1FFFFBFC)
+
 ################################################################################
 ##                        SOURCE DIRECTORIES
 ################################################################################/

--- a/app/wddr_boot/main.c
+++ b/app/wddr_boot/main.c
@@ -31,7 +31,7 @@
 #include "task.h"
 
 /* Kernel includes. */
-#include <kernel/io.h>
+#include <kernel/printf.h>
 
 /* PHY Firmware includes. */
 #include <wddr/memory_map.h>
@@ -56,7 +56,7 @@ static void shutdown(uint32_t cause);
 /*******************************************************************************
 **                           VARIABLE DECLARATIONS
 *******************************************************************************/
-extern uint32_t __start;
+extern uintptr_t __start;
 img_hdr_t image_hdr __attribute__((section(".image_hdr"))) = {
     .image_magic = IMAGE_MAGIC,
     .image_hdr_version = IMAGE_VERSION_CURRENT,
@@ -64,7 +64,8 @@ img_hdr_t image_hdr __attribute__((section(".image_hdr"))) = {
     .version_major = FW_VERSION_MAJOR,
     .version_minor = FW_VERSION_MINOR,
     .version_patch = FW_VERSION_PATCH,
-    .vector_addr = (uint32_t) &__start,
+    .vector_size = VECTOR_SIZE,
+    .vector_addr = (uintptr_t) &__start,
     .device_id = IMAGE_DEVICE_ID_HOST,
     .git_dirty = GIT_DIRTY,
     .git_ahead = GIT_AHEAD,
@@ -103,7 +104,7 @@ static void vMainTask( void *pvParameters )
     // Boot PHY (calibrate but don't train)
     if (firmware_phy_start(BOOT_CALIBRATION, BOOT_TRAINING) == pdFAIL)
     {
-        shutdown(0x10001);
+        shutdown(1);
     }
 
     // Loop forever
@@ -123,7 +124,7 @@ void vApplicationMallocFailedHook( void )
     FreeRTOSConfig.h, and the xPortGetFreeHeapSize() API function can be used
     to query the size of free heap space that remains (although it does not
     provide information on how the remaining heap might be fragmented). */
-    shutdown(0x20001);
+    shutdown(2);
 }
 
 /*-----------------------------------------------------------*/
@@ -149,7 +150,7 @@ void vApplicationStackOverflowHook( TaskHandle_t pxTask, char *pcTaskName )
     /* Run time stack overflow checking is performed if
     configCHECK_FOR_STACK_OVERFLOW is defined to 1 or 2.  This hook
     function is called if a stack overflow is detected. */
-    shutdown(0x30001);
+    shutdown(3);
 }
 
 /*-----------------------------------------------------------*/
@@ -167,28 +168,26 @@ void vAssertCalled( const char * const pcFileName, unsigned long ulLine )
 
     /**
      * @note    This is a patch because on this platform it is known that assert
-     *          will fail for port.c line 161.
+     *          will fail for port.c
      */
     memcpy(&cFileName[0], &pcString[ulFileNameLen - 6], 6);
 
-    if (strcmp(pcFileName, "port.c") && ulLine == 161)
+    // Ignore asserts from port.c
+    if (!strcmp(pcFileName, "port.c"))
     {
         return;
     }
 
     // Write out the file and line number
-    reg_write(WDDR_MEMORY_MAP_MCU + WAV_MCU_GP1_CFG__ADR, ulLine);
-    while (*pcString != '\0')
-    {
-        reg_write(WDDR_MEMORY_MAP_MCU + WAV_MCU_GP2_CFG__ADR, *pcString++);
-    }
-    shutdown(0x40001);
+    configPRINTF(("ERROR: Aserrtion in %s on line %lu.\n", pcFileName, ulLine));
+    taskDISABLE_INTERRUPTS();
+    shutdown(4);
 }
 
 /*-----------------------------------------------------------*/
 static void shutdown(uint32_t cause)
 {
+    configPRINTF(("Shutdown\n"));
     taskDISABLE_INTERRUPTS();
-    reg_write(WDDR_MEMORY_MAP_MCU + WAV_MCU_GP3_CFG__ADR, cause);
-    _exit(1);
+    _exit(cause);
 }

--- a/configure
+++ b/configure
@@ -1,33 +1,25 @@
-#! /bin/sh
+#! /bin/bash
 # Configures build environment for appropriate target architecture
 
 # Definitions
-BUILD_DIR="build"
-BUILD_TYPE=""
+SOURCE_DIR=$(dirname $0)
+WAV_RTOS_DIR=${WAV_RTOS_DIR:-${SOURCE_DIR}/rtos}
 CONFIG_CAL_PLL="true"
 CONFIG_CAL_ZQCAL="true"
 CONFIG_CAL_SA="true"
 CONFIG_DRAM_TRAIN="true"
 CONFIG_CAL_PERIODIC="true"
 
-# Common build prep function
-init_build_common() {
-  mkdir -p ${BUILD_DIR}
-}
-
 init_lpddr() {
-  cd ${BUILD_DIR}
-  cmake .. -DCMAKE_TOOLCHAIN_FILE="../rtos/toolchain/riscv.toolchain" \
-           -DCONFIG_SRC_ARCH="riscv" \
-           -DCONFIG_TARGET_ARCH="riscv32" \
-           -DCONFIG_TARGET_BOARD="wavious-mcu" \
-           -DCONFIG_CALIBRATE_PLL=${CONFIG_CAL_PLL} \
-           -DCONFIG_CALIBRATE_ZQCAL=${CONFIG_CAL_ZQCAL} \
-           -DCONFIG_CALIBRATE_SA=${CONFIG_CAL_SA} \
-           -DCONFIG_DRAM_TRAIN=${CONFIG_DRAM_TRAIN} \
-           -DCONFIG_CAL_PERIODIC=${CONFIG_CAL_PERIODIC} \
-           -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
-  cd ..
+  # Invoke RTOS configure script with addtional parameters
+  args=(
+        -DCONFIG_CALIBRATE_PLL=${CONFIG_CAL_PLL}
+        -DCONFIG_CALIBRATE_ZQCAL=${CONFIG_CAL_ZQCAL}
+        -DCONFIG_CALIBRATE_SA=${CONFIG_CAL_SA}
+        -DCONFIG_DRAM_TRAIN=${CONFIG_DRAM_TRAIN}
+        -DCONFIG_CAL_PERIODIC=${CONFIG_CAL_PERIODIC}
+    )
+    source ${WAV_RTOS_DIR}/configure ${PARAMS} ${args[@]}
 }
 
 print_help() {
@@ -45,10 +37,6 @@ echo "--periodic-cal    (enables periodic calibration)"
 PARAMS=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    -t | --build_type)
-      BUILD_TYPE=$2
-      shift 2
-      ;;
     --no-pll-cal)
       CONFIG_CAL_PLL="false"
       shift 1
@@ -76,10 +64,6 @@ while [ $# -gt 0 ]; do
       shift
       break
       ;;
-    -*|--*=) # unsupported flags
-      echo "Error: Unsupported flag $1" >&2
-      exit 1
-      ;;
     *) # preserve positional arguments
       PARAMS="$PARAMS $1"
       shift
@@ -89,5 +73,4 @@ done
 # set positional arguments in their proper place
 eval set -- "$PARAMS"
 
-init_build_common
 init_lpddr

--- a/include/drivers/wddr/memory_map.h
+++ b/include/drivers/wddr/memory_map.h
@@ -6,7 +6,7 @@
 #ifndef _WDDR_MEMORY_MAP_H_
 #define _WDDR_MEMORY_MAP_H_
 
-#include <board/board.h>
+#include <board/memory_map.h>
 #include "ddr_ca_csr.h"
 #include "ddr_cmn_csr.h"
 #include "ddr_ctrl_csr.h"


### PR DESCRIPTION
Fixes:
  - Fixed issue where MCU IRQ CFG were not set in
    the build system. Previously, these were hard
    coded in wav-rtos-sw but that has since been
    removed (#113).

Features:
  - Integrated wav-rtos-sw v1.3.0
  - Updated configure script to conform to new procedure (#111)
  - Updated applications to use printf and _exit facilities
    (no more reg_writes)