### PR TITLE
Receive Packet Validation Refactor

### DIFF
--- a/include/dev/dfi/buffer.h
+++ b/include/dev/dfi/buffer.h
@@ -81,21 +81,33 @@ dfi_return_t dfi_buffer_fill_and_send_packets(dfi_dev_t *dfi,
                                               const List_t *packet_list);
 
 /**
- * @brief   DFI Buffer Read Packets
+ * @brief   DFI Buffer Read Packet
  *
- * @details Read given number of packets from the EG FIFO.
+ * @details Reads a single packet from the EG FIFO.
  *
- * @param[in]       dfi             pointer to DFI device.
- * @param[out]      rx_buffer       pointer to the RX Packet buffer to read into.
- * @param[inout]    num_packets     number of packets to read / were read.
+ * @param[in]   dfi     pointer to DFI device.
+ * @param[out]  packet  pointer to packet to fill in.
  *
- * @return          returns if requested number of packets were read.
- * @retval          DFI_SUCCESS if number of packets requested were read.
- * @retval          DFI_ERROR_FIFO_EMPTY if EG FIFO is empty before
- *                  number of requested packets have been read.
+ * @return      returns if packet was read.
+ * @retval      DFI_SUCCESS if packet was read.
+ * @retval      DFI_ERROR_FIFO_EMPTY if EG FIFO is empty.
  */
-dfi_return_t dfi_buffer_read_packets(dfi_dev_t *dfi,
-                                      dfi_rx_packet_buffer_t *rx_buffer,
-                                      uint8_t num_packets);
+dfi_return_t dfi_buffer_read_packet(dfi_dev_t *dfi,
+                                    dfi_rx_packet_t *packet);
+
+/**
+ * @brief   DFI Buffer Read All Packets
+ *
+ * @details Reads all packets that are in the EG FIFO.
+ *
+ * @param[in]   dfi             pointer to DFI device.
+ * @param[out]  rx_buffer       pointer to the RX Packet buffer to read into.
+ * @param[out]  num_packets     number of packets that were read.
+ *
+ * @return      void.
+ */
+void dfi_buffer_read_all_packets(dfi_dev_t *dfi,
+                                 dfi_rx_packet_buffer_t *rx_buffer,
+                                 uint8_t *num_packets);
 
 #endif /* _DFI_BUFFER_DEV_H_ */

--- a/include/dev/dfi/packet.h
+++ b/include/dev/dfi/packet.h
@@ -513,28 +513,47 @@ void dfi_tx_packet_buffer_free(dfi_tx_packet_buffer_t *buffer);
 void dfi_rx_packet_buffer_init(dfi_rx_packet_buffer_t *buffer);
 
 /**
- * @brief   DFI RX Packet Buffer Data Comparison
+ * @brief   Extract Packet Data
  *
- * @details Compares given data to data read via received DFI Packets.
+ * @details Extracts data that is in the given packet and writes it into the
+ *          provided buffer.
  *
- * @param[in]   buffer      pointer to rx packet buffer.
- * @param[in]   expected    pointer to expected data.
- * @param[in]   dq_byte     which DQ Byte to compare.
- * @param[in]   data_mask   data mask for which phases to compare.
- * @param[in]   num         number of bytes to compare.
- * @param[in]   phases      number of phases of data to processes. This is
- *                          depedent on current DRAM to DFI Freq ratio.
- * @param[out]  is_same     pointer to store if data matches.
+ * @param[in]   packet  pointer to packet to extract data from.
+ * @param[out]  buffer  pointer to buffer to fill in with packet data.
+ * @param[in]   dq_byte which DQ byte to extract.
+ * @param[in]   phases  number of phases valid in the packet (based on ratio).
  *
- * @return      void
+ * @return      returns whether packet data was valid.
+ * @retval      true if data is valid.
+ * @retval      false otherwise.
  */
-void dfi_rx_packet_buffer_data_compare(const dfi_rx_packet_buffer_t *buffer,
-                                       const command_data_t *expected,
-                                       wddr_dq_byte_t dq_byte,
-                                       packet_data_mask_t data_mask,
-                                       uint8_t num,
-                                       uint8_t phases,
-                                       uint8_t *is_same);
+bool extract_packet_data(const dfi_rx_packet_desc_t *packet,
+                         uint8_t data_packet[PACKET_MAX_NUM_PHASES],
+                         wddr_dq_byte_t dq_byte,
+                         uint8_t phases);
+
+/**
+ * @brief   Compare Packet Data
+ *
+ * @details Compares the packet data to the expected data. Data mask indicates
+ *          if odd or even phases or both should be compared. Typically, both
+ *          phases are compared, but in some cases it might be useful to only
+ *          compare even or odds.
+ *
+ * @param[in]   ptr1    pointer to data to compare.
+ * @param[in]   ptr2    pointer to data to compare against.
+ * @param[in]   phases  number of phases per packet. 1 phase = 1 byte of data.
+ * @param[in]   mask    mask to indicate if even, odd, or both phases are
+ *                      compared.
+ *
+ * @return      returns whether packet data matches.
+ * @retval      true if data matches.
+ * @retval      false otherwise.
+ */
+bool compare_packet_data(const uint8_t *ptr1,
+                         const uint8_t *ptr2,
+                         uint8_t phases,
+                         packet_data_mask_t mask);
 
 /**
  * @brief   Create CK Packet Sequence

--- a/include/dev/wddr/interface.h
+++ b/include/dev/wddr/interface.h
@@ -430,19 +430,18 @@ wddr_return_t wddr_send_packets(wddr_handle_t wddr, const List_t *packets);
  *
  * @details Validates that data received matches expected values.
  *
- * @param[in]   wddr    WDDR device handle.
- * @param[in]   data    data that is expected to be received.
- * @param[in]   bl      Burst length of data expected to recieve.
- * @param[out]  valid   pointer to store if data was validated.
+ * @param[in]   wddr            WDDR device handle.
+ * @param[in]   data            data that is expected to be received.
+ * @param[in]   bl              Burst length of data expected to recieve.
+ * @param[in]   dq_byte_mask    mask to indicate which DQ bytes to validate.
  *
- * @return      returns whether data was validated successfully.
- * @retval      WDDR_SUCCESS if successful.
- * @retval      WDDR_ERROR_FIFO_EMPTY if FIFO is empty.
- * @retval      WDDR_ERROR otherwise.
+ * @return      returns whether received data was valid.
+ * @retval      true if received data matches expected data.
+ * @retval      false otherwise.
  */
-wddr_return_t wddr_validate_recv_data(wddr_handle_t wddr,
-                                      const command_data_t *data,
-                                      burst_length_t bl,
-                                      bool *valid);
+bool wddr_validate_recv_data(wddr_handle_t wddr,
+                             const command_data_t *data,
+                             burst_length_t bl,
+                             uint8_t dq_byte_mask);
 
 #endif /* _WDDR_INTERFACE_H_ */


### PR DESCRIPTION
Fixes:
  - None

Features:
  - WDDR Interface implementation updated so that rx_buffer
    does not need to be pre-allocated for receive data validation.
  - Deleted API to validate receive data (moved into wddr/device.c).
  - Added DFI FIFO API to read all packets.
  - Added DFI FIFO API to read single packet.