### PR TITLE
App Assert Fix

### DIFF
--- a/app/wddr_boot/main.c
+++ b/app/wddr_boot/main.c
@@ -168,12 +168,12 @@ void vAssertCalled( const char * const pcFileName, unsigned long ulLine )
 
     /**
      * @note    This is a patch because on this platform it is known that assert
-     *          will fail for port.c
+     *          will fail for port.c.
      */
     memcpy(&cFileName[0], &pcString[ulFileNameLen - 6], 6);
 
     // Ignore asserts from port.c
-    if (!strcmp(pcFileName, "port.c"))
+    if (!strcmp(cFileName, "port.c"))
     {
         return;
     }

--- a/app/wddr_main/main.c
+++ b/app/wddr_main/main.c
@@ -225,12 +225,12 @@ void vAssertCalled( const char * const pcFileName, unsigned long ulLine )
 
     /**
      * @note    This is a patch because on this platform it is known that assert
-     *          will fail for port.c line 161.
+     *          will fail for port.c.
      */
     memcpy(&cFileName[0], &pcString[ulFileNameLen - 6], 6);
 
     // Ignore asserts from port.c
-    if (!strcmp(pcFileName, "port.c"))
+    if (!strcmp(cFileName, "port.c"))
     {
         return;
     }


### PR DESCRIPTION
Fixes:
  - Fixed issue in vAssertCalled implementation where string
    compare was done against the wrong variable.

Features:
  - None